### PR TITLE
Improve adapter-nostr-tools

### DIFF
--- a/packages/@nostr-fetch/adapter-nostr-tools/src/index.ts
+++ b/packages/@nostr-fetch/adapter-nostr-tools/src/index.ts
@@ -270,10 +270,5 @@ class SimplePoolAdapter implements RelayPoolHandle {
 
 /**
  * Wraps a nostr-tools' `SimplePool`, allowing it to interoperate with nostr-fetch.
- *
- * Limitations: if you use this adapter, some fetch options will be ignored (for now):
- *
- * - `connectTimeoutMs`
- * - `abortSubBeforeEoseTimeoutMs`
  */
 export const simplePoolAdapter = (sp: SimplePool): RelayPoolHandle => new SimplePoolAdapter(sp);

--- a/packages/nostr-fetch/src/fetcher.ts
+++ b/packages/nostr-fetch/src/fetcher.ts
@@ -409,7 +409,9 @@ export class NostrFetcher {
     });
     sub.on("eose", ({ aborted }) => {
       if (aborted) {
-        this.#logForDebug?.(`subscription (id: ${sub.subId}) aborted before EOSE due to timeout`);
+        this.#logForDebug?.(
+          `[${relay.url}] subscription (id: ${sub.subId}) aborted before EOSE due to timeout`
+        );
       }
 
       sub.close();
@@ -419,7 +421,9 @@ export class NostrFetcher {
 
     // handle abortion
     signal?.addEventListener("abort", () => {
-      this.#logForDebug?.(`subscription (id: ${sub.subId}) aborted via AbortController`);
+      this.#logForDebug?.(
+        `[${relay.url}] subscription (id: ${sub.subId}) aborted via AbortController`
+      );
 
       sub.close();
       tx.close();


### PR DESCRIPTION
Added true support for following fetch options to the `SimplePoolAdapter`:
- `connectTimeoutMs`
- `abortSubBeforeEoseTimeoutMs`