### PR TITLE
Fix a bug in auto subscription abortion (adapter-nostr-tools)

### DIFF
--- a/packages/@nostr-fetch/adapter-nostr-tools/src/index.ts
+++ b/packages/@nostr-fetch/adapter-nostr-tools/src/index.ts
@@ -49,6 +49,9 @@ class ToolsSubAdapter implements Subscription {
       id: this.#subId,
     });
 
+    // initiate subscription auto abortion timer
+    this.resetAbortSubTimer();
+
     // register callbacks which control subscription auto abortion
     this.registerCb("event", () => {
       // reset the auto abortion timer every time a new event arrives

--- a/packages/@nostr-fetch/examples/src/utils.ts
+++ b/packages/@nostr-fetch/examples/src/utils.ts
@@ -5,4 +5,5 @@ export const defaultRelays = [
   "wss://relay-jp.nostr.wirednet.jp",
   "wss://nostr.h3z.jp",
   "wss://nostr.holybea.com",
+  "wss://nostr-relay.nokotaro.com",
 ];


### PR DESCRIPTION
The auto abortion timer didn't start if no events were sent from a relay.  To fix this, made the timer start right after REQ.