### PR TITLE
Migrate to the better relay pool abstraction

### DIFF
--- a/packages/@nostr-fetch/adapter-nostr-tools/src/index.ts
+++ b/packages/@nostr-fetch/adapter-nostr-tools/src/index.ts
@@ -123,7 +123,7 @@ class ToolsSubAdapter implements Subscription {
     }
   }
 
-  // transfers a callback registration to the inner `Sub`
+  // forwards a callback registration to the inner `Sub`
   private registerCb<E extends keyof SubEventCbTypes>(type: E, cb: SubEventCbTypes[E]): void {
     if (this.#sub === undefined) {
       console.error("ToolsSubAdapter: inner Sub is undefined");
@@ -137,7 +137,7 @@ class ToolsSubAdapter implements Subscription {
 
       case "eose": {
         // adapt callbacks for `eose` events
-        // adapted callback should be called when actual EOSE is received, so it should just call the original callback with { aborted: false }.
+        // adapted callback will be called when actual EOSE is received, so it should just call the original callback with { aborted: false }.
         const adapted = () => (cb as SubEoseCb)({ aborted: false });
         this.#onEoseAdapted.set(cb as SubEoseCb, adapted);
         this.#sub.on("eose", adapted);
@@ -146,7 +146,7 @@ class ToolsSubAdapter implements Subscription {
     }
   }
 
-  // transfers a callback unregistration to the inner `Sub`
+  // forwards a callback unregistration to the inner `Sub`
   private unregisterCb<E extends keyof SubEventCbTypes>(type: E, cb: SubEventCbTypes[E]): void {
     if (this.#sub === undefined) {
       console.error("ToolsSubAdapter: inner Sub is undefined");
@@ -262,7 +262,7 @@ class SimplePoolAdapter implements RelayPoolHandle {
             r.on("disconnect", () => this.#logForDebug?.(`[${url}] disconnected`));
             r.on("error", () => this.#logForDebug?.(`[${url}] WebSocket error`));
             r.on("notice", (notice) => this.#logForDebug?.(`[${url}] NOTICE: ${notice}`));
-            r.on("auth", () => this.#logForDebug?.(`[${url} received AUTH challange (ignoring)`));
+            r.on("auth", () => this.#logForDebug?.(`[${url}] received AUTH challange (ignoring)`));
 
             return new ToolsRelayAdapter(url, r);
           }),

--- a/packages/@nostr-fetch/examples/src/abort.ts
+++ b/packages/@nostr-fetch/examples/src/abort.ts
@@ -7,7 +7,7 @@ const main = async () => {
   const fetcher = NostrFetcher.init();
   const abortCtrl = new AbortController();
 
-  // fetch all text events (kind: 1) posted in last 24 hours from the relays
+  // fetch all text events (kind: 1) posted in the last hour from the relays
   const evIter = await fetcher.allEventsIterator(
     defaultRelays,
     [
@@ -16,7 +16,7 @@ const main = async () => {
       },
     ],
     {
-      since: nHoursAgo(24),
+      since: nHoursAgo(1),
     },
     { abortSignal: abortCtrl.signal } // pass `AbortController.signal` to enable abortion
   );

--- a/packages/@nostr-fetch/examples/src/fetchAll.ts
+++ b/packages/@nostr-fetch/examples/src/fetchAll.ts
@@ -6,7 +6,7 @@ import { defaultRelays, nHoursAgo } from "./utils";
 const main = async () => {
   const fetcher = NostrFetcher.init();
 
-  // fetch all text events (kind: 1) posted in last 24 hours from the relays
+  // fetch all text events (kind: 1) posted in last hour from the relays
   const events = await fetcher.fetchAllEvents(
     defaultRelays,
     [
@@ -15,7 +15,7 @@ const main = async () => {
       },
     ],
     {
-      since: nHoursAgo(24),
+      since: nHoursAgo(1),
     },
     { sort: true }
   );

--- a/packages/@nostr-fetch/examples/src/interop/simplePool.ts
+++ b/packages/@nostr-fetch/examples/src/interop/simplePool.ts
@@ -8,7 +8,7 @@ import { defaultRelays, nHoursAgo } from "../utils";
 const main = async () => {
   // initialize fetcher based on nostr-tools `SimplePool`
   const pool = new SimplePool();
-  const fetcher = NostrFetcher.withRelayPool(simplePoolAdapter(pool));
+  const fetcher = NostrFetcher.withCustomPool(simplePoolAdapter(pool));
 
   // fetch all text events (kind: 1) posted in last 24 hours from the relays
   const eventsIter = await fetcher.allEventsIterator(

--- a/packages/@nostr-fetch/examples/src/interop/simplePool.ts
+++ b/packages/@nostr-fetch/examples/src/interop/simplePool.ts
@@ -10,7 +10,7 @@ const main = async () => {
   const pool = new SimplePool();
   const fetcher = NostrFetcher.withCustomPool(simplePoolAdapter(pool));
 
-  // fetch all text events (kind: 1) posted in last 24 hours from the relays
+  // fetch all text events (kind: 1) posted in the last hour from the relays
   const eventsIter = await fetcher.allEventsIterator(
     defaultRelays,
     [
@@ -19,7 +19,7 @@ const main = async () => {
       },
     ],
     {
-      since: nHoursAgo(24),
+      since: nHoursAgo(1),
     },
     {
       skipVerification: true,

--- a/packages/nostr-fetch/src/fetcher.ts
+++ b/packages/nostr-fetch/src/fetcher.ts
@@ -1,8 +1,12 @@
 import { Channel } from "./channel";
 import { verifyEventSig } from "./crypto";
+import {
+  DefaultFetcherBase,
+  type FetchTillEoseOptions,
+  type NostrFetcherBase,
+} from "./fetcherBase";
 import type { Filter, NostrEvent } from "./nostr";
-import { initRelayPool } from "./relayPool";
-import type { RelayHandle, RelayPoolHandle, SubscriptionOptions } from "./relayTypes";
+import { emptyAsyncGen } from "./utils";
 
 export type FetchFilter = Omit<Filter, "limit" | "since" | "until">;
 export type FetchTimeRangeFilter = Pick<Filter, "since" | "until">;
@@ -51,17 +55,13 @@ const defaultFetchLatestOptions: Required<FetchLatestOptions> = {
   reduceVerification: true,
 };
 
-// eslint-disable-next-line require-yield
-async function* emptyAsyncGen() {
-  return;
-}
-
 export class NostrFetcher {
-  #relayPool: RelayPoolHandle;
+  // #relayPool: RelayPoolHandle;
+  #fetcherBase: NostrFetcherBase;
   #logForDebug: typeof console.log | undefined;
 
-  private constructor(relayPool: RelayPoolHandle, initOpts: Required<FetcherInitOptions>) {
-    this.#relayPool = relayPool;
+  private constructor(fetcherBase: NostrFetcherBase, initOpts: Required<FetcherInitOptions>) {
+    this.#fetcherBase = fetcherBase;
 
     if (initOpts.enableDebugLog) {
       this.#logForDebug = console.log;
@@ -73,21 +73,23 @@ export class NostrFetcher {
    */
   public static init(initOpts: FetcherInitOptions = {}) {
     const finalOpts = { ...defaultFetcherInitOptions, ...initOpts };
-    const rp = initRelayPool(finalOpts);
-    return new NostrFetcher(rp, finalOpts);
+    const base = new DefaultFetcherBase(finalOpts);
+    return new NostrFetcher(base, finalOpts);
   }
 
   /**
-   * Initializes `NostrFetcher` with the given relay pool implementation.
+   * Initializes `NostrFetcher` with the given custom relay pool implementation.
    *
+   *
+   * @example
    * ```ts
    * const pool = new SimplePool();
    * const fetcher = NostrFetcher.withRelayPool(simplePoolAdapter(pool));
    * ```
    */
-  public static withRelayPool(relayPool: RelayPoolHandle, initOpts: FetcherInitOptions = {}) {
+  public static withCustomPool(base: NostrFetcherBase, initOpts: FetcherInitOptions = {}) {
     const finalOpts = { ...defaultFetcherInitOptions, ...initOpts };
-    return new NostrFetcher(relayPool, finalOpts);
+    return new NostrFetcher(base, finalOpts);
   }
 
   /**
@@ -123,14 +125,14 @@ export class NostrFetcher {
       return emptyAsyncGen();
     }
 
-    const relays = await this.#relayPool.ensureRelays(relayUrls, finalOpts);
+    await this.#fetcherBase.ensureRelays(relayUrls, finalOpts);
 
     const [tx, chIter] = Channel.make<NostrEvent>();
     const globalSeenEventIds = new Set<string>();
     const initialUntil = timeRangeFilter.until ?? Math.floor(Date.now() / 1000);
 
     Promise.all(
-      relays.map(async (r) => {
+      relayUrls.map(async (rurl) => {
         let nextUntil = initialUntil;
         const localSeenEventIds = new Set<string>();
         while (true) {
@@ -148,12 +150,7 @@ export class NostrFetcher {
           let numNewEvents = 0;
           let oldestCreatedAt = Number.MAX_SAFE_INTEGER;
 
-          for await (const e of this.fetchEventsTillEose(
-            r,
-            refinedFilters,
-            finalOpts,
-            finalOpts.abortSignal
-          )) {
+          for await (const e of this.#fetcherBase.fetchTillEose(rurl, refinedFilters, finalOpts)) {
             // eliminate duplicated events
             if (!localSeenEventIds.has(e.id)) {
               numNewEvents++;
@@ -170,11 +167,11 @@ export class NostrFetcher {
           }
 
           if (finalOpts.abortSignal?.aborted) {
-            this.#logForDebug?.(`[${r.url}] aborted`);
+            this.#logForDebug?.(`[${rurl}] aborted`);
             break;
           }
           if (numNewEvents === 0) {
-            this.#logForDebug?.(`[${r.url}] got ${localSeenEventIds.size} events`);
+            this.#logForDebug?.(`[${rurl}] got ${localSeenEventIds.size} events`);
             break;
           }
           // set next `until` to `created_at` of the oldest event returned in this time.
@@ -253,12 +250,12 @@ export class NostrFetcher {
       return [];
     }
 
-    const relays = await this.#relayPool.ensureRelays(relayUrls, finalOpts);
+    await this.#fetcherBase.ensureRelays(relayUrls, finalOpts);
 
     const [tx, chIter] = Channel.make<NostrEvent>();
     const globalSeenEventIds = new Set<string>();
     const initialUntil = Math.floor(Date.now() / 1000);
-    const subOpts: SubscriptionOptions = {
+    const subOpts: FetchTillEoseOptions = {
       ...finalOpts,
       // skip "full" verification if `reduceVerification` is enabled
       skipVerification: finalOpts.skipVerification || finalOpts.reduceVerification,
@@ -266,7 +263,7 @@ export class NostrFetcher {
 
     // fetch at most `limit` events from each relay
     Promise.all(
-      relays.map(async (r) => {
+      relayUrls.map(async (rurl) => {
         let nextUntil = initialUntil;
         let remainingLimit = limit;
 
@@ -286,12 +283,7 @@ export class NostrFetcher {
           let numNewEvents = 0;
           let oldestCreatedAt = Number.MAX_SAFE_INTEGER;
 
-          for await (const e of this.fetchEventsTillEose(
-            r,
-            refinedFilters,
-            subOpts,
-            finalOpts.abortSignal
-          )) {
+          for await (const e of this.#fetcherBase.fetchTillEose(rurl, refinedFilters, subOpts)) {
             // eliminate duplicated events
             if (!localSeenEventIds.has(e.id)) {
               numNewEvents++;
@@ -308,13 +300,13 @@ export class NostrFetcher {
           }
 
           if (finalOpts.abortSignal?.aborted) {
-            this.#logForDebug?.(`[${r.url}] aborted`);
+            this.#logForDebug?.(`[${rurl}] aborted`);
             break;
           }
 
           remainingLimit -= numNewEvents;
           if (numNewEvents === 0 || remainingLimit <= 0) {
-            this.#logForDebug?.(`[${r.url}] got ${localSeenEventIds.size} events`);
+            this.#logForDebug?.(`[${rurl}] got ${localSeenEventIds.size} events`);
             break;
           }
 
@@ -376,67 +368,10 @@ export class NostrFetcher {
     return latest1[0];
   }
 
-  private fetchEventsTillEose(
-    relay: RelayHandle,
-    filters: Filter[],
-    subOpts: SubscriptionOptions,
-    signal: AbortSignal | undefined
-  ): AsyncIterable<NostrEvent> {
-    const [tx, chIter] = Channel.make<NostrEvent>();
-
-    const onNotice = (n: unknown) => {
-      tx.error(Error(`NOTICE: ${JSON.stringify(n)}`));
-      removeRelayListeners();
-    };
-    const onError = () => {
-      tx.error(Error("ERROR"));
-      removeRelayListeners();
-    };
-    const removeRelayListeners = () => {
-      relay.off("notice", onNotice);
-      relay.off("error", onError);
-    };
-
-    relay.on("notice", onNotice);
-    relay.on("error", onError);
-
-    // prepare a subscription
-    const sub = relay.prepareSub(filters, subOpts);
-
-    // handle subscription events
-    sub.on("event", (ev: NostrEvent) => {
-      tx.send(ev);
-    });
-    sub.on("eose", ({ aborted }) => {
-      if (aborted) {
-        this.#logForDebug?.(
-          `[${relay.url}] subscription (id: ${sub.subId}) aborted before EOSE due to timeout`
-        );
-      }
-
-      sub.close();
-      tx.close();
-      removeRelayListeners();
-    });
-
-    // handle abortion
-    signal?.addEventListener("abort", () => {
-      this.#logForDebug?.(
-        `[${relay.url}] subscription (id: ${sub.subId}) aborted via AbortController`
-      );
-
-      sub.close();
-      tx.close();
-      removeRelayListeners();
-    });
-
-    // start the subscription
-    sub.req();
-
-    return chIter;
-  }
-
+  /**
+   * Closes all the connections to relays and clean up the internal relay pool.
+   */
   public shutdown() {
-    this.#relayPool.closeAll();
+    this.#fetcherBase.closeAll();
   }
 }

--- a/packages/nostr-fetch/src/fetcherBase.ts
+++ b/packages/nostr-fetch/src/fetcherBase.ts
@@ -1,0 +1,140 @@
+import { Channel } from "./channel";
+import type { Filter, NostrEvent } from "./nostr";
+import type { RelayPoolOptions } from "./relayPool";
+import { RelayPool, initRelayPool } from "./relayPool";
+import { emptyAsyncGen } from "./utils";
+
+type EnsureRelaysOptions = {
+  connectTimeoutMs: number;
+};
+
+export type FetchTillEoseOptions = {
+  subId?: string;
+  skipVerification: boolean;
+  connectTimeoutMs: number;
+  abortSubBeforeEoseTimeoutMs: number;
+  abortSignal: AbortSignal | undefined;
+};
+
+/**
+ * Set of APIs to fetch past events from nostr relays.
+ *
+ * `NostrFetcher` implements its functions on top of this.
+ */
+export interface NostrFetcherBase {
+  /**
+   * Ensures connections to the relays prior to an event subscription.
+   */
+  ensureRelays: (relayUrls: string[], options: EnsureRelaysOptions) => Promise<void>;
+
+  /**
+   * Closes all connections to relays.
+   */
+  closeAll: () => void;
+
+  /**
+   * Fetches Nostr events matching `filters` from the relay specified by `relayUrl` until EOSE.
+   *
+   * The result is an `AsyncIterable` of Nostr events.
+   * You can think that it's an asynchronous channel which conveys events.
+   * The channel will be closed once EOSE is reached.
+   *
+   * If no connection to the specified relay has been established at the time this function is called, it will return an empty channel.
+   *
+   * Hint:
+   * You can make use of a `Channel` to convert "push" style code (bunch of event listers) to `AsyncIterable`.
+   */
+  fetchTillEose: (
+    relayUrl: string,
+    filters: Filter[],
+    options: FetchTillEoseOptions
+  ) => AsyncIterable<NostrEvent>;
+}
+
+/**
+ * Default implementation of `NostrFetchBase`.
+ */
+export class DefaultFetcherBase implements NostrFetcherBase {
+  #relayPool: RelayPool;
+  #logForDebug: typeof console.log | undefined;
+
+  public constructor(options: RelayPoolOptions) {
+    this.#relayPool = initRelayPool(options);
+    if (options.enableDebugLog) {
+      this.#logForDebug = console.log;
+    }
+  }
+
+  public async ensureRelays(relayUrls: string[], options: EnsureRelaysOptions): Promise<void> {
+    await this.#relayPool.ensureRelays(relayUrls, options);
+  }
+
+  public closeAll(): void {
+    this.#relayPool.closeAll();
+  }
+
+  public fetchTillEose(
+    relayUrl: string,
+    filters: Filter[],
+    options: FetchTillEoseOptions
+  ): AsyncIterable<NostrEvent> {
+    const [tx, chIter] = Channel.make<NostrEvent>();
+
+    const relay = this.#relayPool.getRelayIfConnected(relayUrl);
+    if (relay === undefined) {
+      return emptyAsyncGen();
+    }
+
+    // error handlings
+    const onNotice = (n: unknown) => {
+      tx.error(Error(`NOTICE: ${JSON.stringify(n)}`));
+      removeRelayListeners();
+    };
+    const onError = () => {
+      tx.error(Error("ERROR"));
+      removeRelayListeners();
+    };
+    const removeRelayListeners = () => {
+      relay.off("notice", onNotice);
+      relay.off("error", onError);
+    };
+
+    relay.on("notice", onNotice);
+    relay.on("error", onError);
+
+    // prepare a subscription
+    const sub = relay.prepareSub(filters, options);
+
+    // handle subscription events
+    sub.on("event", (ev: NostrEvent) => {
+      tx.send(ev);
+    });
+    sub.on("eose", ({ aborted }) => {
+      if (aborted) {
+        this.#logForDebug?.(
+          `[${relay.url}] subscription (id: ${sub.subId}) aborted before EOSE due to timeout`
+        );
+      }
+
+      sub.close();
+      tx.close();
+      removeRelayListeners();
+    });
+
+    // handle abortion
+    options.abortSignal?.addEventListener("abort", () => {
+      this.#logForDebug?.(
+        `[${relay.url}] subscription (id: ${sub.subId}) aborted via AbortController`
+      );
+
+      sub.close();
+      tx.close();
+      removeRelayListeners();
+    });
+
+    // start the subscription
+    sub.req();
+
+    return chIter;
+  }
+}

--- a/packages/nostr-fetch/src/fetcherBase.ts
+++ b/packages/nostr-fetch/src/fetcherBase.ts
@@ -4,7 +4,7 @@ import type { RelayPoolOptions } from "./relayPool";
 import { RelayPool, initRelayPool } from "./relayPool";
 import { emptyAsyncGen } from "./utils";
 
-type EnsureRelaysOptions = {
+export type EnsureRelaysOptions = {
   connectTimeoutMs: number;
 };
 
@@ -28,7 +28,7 @@ export interface NostrFetcherBase {
   ensureRelays: (relayUrls: string[], options: EnsureRelaysOptions) => Promise<void>;
 
   /**
-   * Closes all connections to relays.
+   * Closes all the connections to relays and clean up the internal relay pool.
    */
   closeAll: () => void;
 

--- a/packages/nostr-fetch/src/relay.ts
+++ b/packages/nostr-fetch/src/relay.ts
@@ -7,7 +7,6 @@ import type {
   RelayErrorCb,
   RelayEventCbTypes,
   RelayEventTypes,
-  RelayHandle,
   RelayNoticeCb,
   RelayOptions,
   SubEoseCb,
@@ -18,7 +17,7 @@ import type {
   SubscriptionOptions,
 } from "./relayTypes";
 
-export interface Relay extends RelayHandle {
+export interface Relay {
   url: string;
   connect(): Promise<Relay>;
   close(): void;

--- a/packages/nostr-fetch/src/relayPool.ts
+++ b/packages/nostr-fetch/src/relayPool.ts
@@ -2,7 +2,6 @@ import { Filter, generateSubId, NostrEvent } from "./nostr";
 import { initRelay, Relay } from "./relay";
 import type {
   RelayOptions,
-  RelayPoolHandle,
   SubEoseCb,
   SubEventCb,
   SubEventCbTypes,
@@ -12,7 +11,7 @@ import type {
 } from "./relayTypes";
 import { currUnixtimeMilli, normalizeRelayUrl, normalizeRelayUrls } from "./utils";
 
-export interface RelayPool extends RelayPoolHandle {
+export interface RelayPool {
   ensureRelays(relayUrls: string[], relayOpts: RelayOptions): Promise<Relay[]>;
   getRelayIfConnected(relayUrl: string): Relay | undefined;
   closeAll(): void;

--- a/packages/nostr-fetch/src/relayPool.ts
+++ b/packages/nostr-fetch/src/relayPool.ts
@@ -10,7 +10,7 @@ import type {
   Subscription,
   SubscriptionOptions,
 } from "./relayTypes";
-import { currUnixtimeMilli, normalizeRelayUrls } from "./utils";
+import { currUnixtimeMilli, normalizeRelayUrl, normalizeRelayUrls } from "./utils";
 
 export interface RelayPool extends RelayPoolHandle {
   ensureRelays(relayUrls: string[], relayOpts: RelayOptions): Promise<Relay[]>;
@@ -57,6 +57,7 @@ type DisconnectedRelay = {
 type ManagedRelay = AliveRelay | ConnectingRelay | ConnectFailedRelay | DisconnectedRelay;
 
 class RelayPoolImpl implements RelayPool {
+  // keys are **normalized** relay URLs
   #relays: Map<string, ManagedRelay> = new Map();
   #logForDebug: typeof console.log | undefined;
 
@@ -138,7 +139,7 @@ class RelayPoolImpl implements RelayPool {
   }
 
   public getRelayIfConnected(relayUrl: string): Relay | undefined {
-    const r = this.#relays.get(relayUrl);
+    const r = this.#relays.get(normalizeRelayUrl(relayUrl));
     if (r === undefined) {
       return undefined;
     }

--- a/packages/nostr-fetch/src/relayPool.ts
+++ b/packages/nostr-fetch/src/relayPool.ts
@@ -14,6 +14,7 @@ import { currUnixtimeMilli, normalizeRelayUrls } from "./utils";
 
 export interface RelayPool extends RelayPoolHandle {
   ensureRelays(relayUrls: string[], relayOpts: RelayOptions): Promise<Relay[]>;
+  getRelayIfConnected(relayUrl: string): Relay | undefined;
   closeAll(): void;
 
   // prepareSub(
@@ -134,6 +135,17 @@ class RelayPoolImpl implements RelayPool {
       }
     }
     return res;
+  }
+
+  public getRelayIfConnected(relayUrl: string): Relay | undefined {
+    const r = this.#relays.get(relayUrl);
+    if (r === undefined) {
+      return undefined;
+    }
+    if (r.state !== "alive") {
+      return undefined;
+    }
+    return r.relay;
   }
 
   public async prepareSub(

--- a/packages/nostr-fetch/src/relayTypes.ts
+++ b/packages/nostr-fetch/src/relayTypes.ts
@@ -1,4 +1,4 @@
-import type { Filter, NostrEvent } from "./nostr";
+import type { NostrEvent } from "./nostr";
 
 type Callback<E> = E extends void ? () => void : (ev: E) => void;
 
@@ -47,17 +47,3 @@ export interface SubscriptionOptions {
   skipVerification: boolean;
   abortSubBeforeEoseTimeoutMs: number;
 }
-
-// minimum APIs for relay handles that is required to fetch events.
-export type RelayHandle = {
-  url: string;
-  prepareSub(filters: Filter[], options: SubscriptionOptions): Subscription;
-  on<E extends RelayEventTypes>(type: E, cb: RelayEventCbTypes[E]): void;
-  off<E extends RelayEventTypes>(type: E, cb: RelayEventCbTypes[E]): void;
-};
-
-// minimum APIs for relay pool handles that is required to fetch events.
-export type RelayPoolHandle = {
-  ensureRelays(relayUrls: string[], relayOpts: RelayOptions): Promise<RelayHandle[]>;
-  closeAll(): void;
-};

--- a/packages/nostr-fetch/src/utils.ts
+++ b/packages/nostr-fetch/src/utils.ts
@@ -29,3 +29,9 @@ const dedup = <T>(items: T[]): T[] => {
 export const normalizeRelayUrls = (relayUrls: string[]): string[] => {
   return dedup(relayUrls.map((u) => normalizeRelayUrl(u)));
 };
+
+// empty AsyncGenerator
+// eslint-disable-next-line require-yield
+export async function* emptyAsyncGen() {
+  return;
+}


### PR DESCRIPTION
I found that we can't implement adapter for [nostr-relaypool-ts](https://github.com/adamritter/nostr-relaypool-ts) on top of current abstractions (`RelayPoolHandle`/`RelayHandle`/`Subscription`) since it doesn't export concrete `Relay`/`Sub` types (customized from `nostr-tools`'s impls).

Instead, make `fetchTillEose` (renamed from `fetchEventTillEose`) the core abstraction of "event fetcher". It has existed as a helper method of the `NostrFetcher`, but it actually is the heart of the event fetching! With this abstraction, we can implement adapters for relay pool impls even they don't expose internal types ("relay" / "subscription").