### PR TITLE
Rename: closeAll -> shutdown

### DIFF
--- a/packages/adapter-nostr-relaypool/src/index.ts
+++ b/packages/adapter-nostr-relaypool/src/index.ts
@@ -150,11 +150,11 @@ class NRTPoolAdapter implements NostrFetcherBase {
   }
 
   /**
-   * Cleans up the internal relay pool.
+   * Cleans up all the internal states of the fetcher.
    *
-   * It actually doesn't close any connections to relays, because other codes may reuse them.
+   * It doesn't close any connections to relays, because other codes may reuse them.
    */
-  public closeAll(): void {
+  public shutdown(): void {
     // just clear listeners map
     for (const m of Object.values(this.#listeners)) {
       m.clear();

--- a/packages/adapter-nostr-tools/src/index.ts
+++ b/packages/adapter-nostr-tools/src/index.ts
@@ -304,11 +304,11 @@ class SimplePoolExt implements NostrFetcherBase {
   }
 
   /**
-   * Cleans up the internal relay pool.
+   * Cleans up all the internal states of the fetcher.
    *
-   * It actually doesn't close any connections to relays, because other codes may reuse them.
+   * It doesn't close any connections to relays, because other codes may reuse them.
    */
-  public closeAll(): void {
+  public shutdown(): void {
     // just clear extra refs to `RelayExt`s
     this.#relays.clear();
   }

--- a/packages/nostr-fetch-kernel/src/fetcherBase.ts
+++ b/packages/nostr-fetch-kernel/src/fetcherBase.ts
@@ -32,9 +32,9 @@ export interface NostrFetcherBase {
   ensureRelays(relayUrls: string[], options: EnsureRelaysOptions): Promise<string[]>;
 
   /**
-   * Closes all the connections to relays and clean up the internal relay pool.
+   * Cleans up all the internal states of the fetcher.
    */
-  closeAll(): void;
+  shutdown(): void;
 
   /**
    * Fetches Nostr events matching `filters` from the relay specified by `relayUrl` until EOSE.

--- a/packages/nostr-fetch/src/fetcher.ts
+++ b/packages/nostr-fetch/src/fetcher.ts
@@ -631,10 +631,10 @@ export class NostrFetcher {
   }
 
   /**
-   * Closes all the connections to relays and clean up the internal relay pool.
+   * Cleans up all the internal states of the fetcher.
    */
   public shutdown() {
-    this.#fetcherBase.closeAll();
+    this.#fetcherBase.shutdown();
   }
 }
 

--- a/packages/nostr-fetch/src/fetcherBase.ts
+++ b/packages/nostr-fetch/src/fetcherBase.ts
@@ -39,8 +39,8 @@ export class DefaultFetcherBase implements NostrFetcherBase {
   /**
    * Closes all the connections to relays and clean up the internal relay pool.
    */
-  public closeAll(): void {
-    this.#relayPool.closeAll();
+  public shutdown(): void {
+    this.#relayPool.shutdown();
   }
 
   /**

--- a/packages/nostr-fetch/src/relayPool.ts
+++ b/packages/nostr-fetch/src/relayPool.ts
@@ -20,7 +20,7 @@ import { Relay, initRelay } from "./relay";
 export interface RelayPool {
   ensureRelays(relayUrls: string[], relayOpts: RelayOptions): Promise<Relay[]>;
   getRelayIfConnected(relayUrl: string): Relay | undefined;
-  closeAll(): void;
+  shutdown(): void;
 
   // prepareSub(
   //   relayUrls: string[],
@@ -180,7 +180,12 @@ class RelayPoolImpl implements RelayPool {
     return new RelayPoolSubscription(subId, subs);
   }
 
-  public closeAll() {
+  /**
+   * Cleans up all the internal states of the fetcher.
+   *
+   * It also closes all the connections to the relays.
+   */
+  public shutdown() {
     for (const [, r] of this.#relays) {
       if (r.state === "alive") {
         r.relay.close();


### PR DESCRIPTION
Renamed the `closeAll` method of `NostrFetcherBase` to `shutdown`.

The name `closeAll` didn't match the reality of several implementations
(they don't close anything, instead just clean up their internal states).

resolves #15 