### PR TITLE
Improve ergonomics of initializing NostrFetcher

### DIFF
--- a/packages/adapter-nostr-tools/src/index.ts
+++ b/packages/adapter-nostr-tools/src/index.ts
@@ -1,6 +1,11 @@
 import { Channel } from "@nostr-fetch/kernel/channel";
-import { DebugLogger, LogLevel } from "@nostr-fetch/kernel/debugLogger";
-import type { FetchTillEoseOptions, NostrFetcherBase } from "@nostr-fetch/kernel/fetcherBase";
+import { DebugLogger } from "@nostr-fetch/kernel/debugLogger";
+import type {
+  FetchTillEoseOptions,
+  NostrFetcherBase,
+  NostrFetcherBaseInitializer,
+  NostrFetcherCommonOptions,
+} from "@nostr-fetch/kernel/fetcherBase";
 import { NostrEvent, generateSubId, type Filter } from "@nostr-fetch/kernel/nostr";
 import type {
   RelayEventCbTypes,
@@ -218,14 +223,6 @@ class ToolsRelayExt {
   }
 }
 
-type SimplePoolExtOptions = {
-  minLogLevel?: LogLevel;
-};
-
-const defaultExtOptions: Required<SimplePoolExtOptions> = {
-  minLogLevel: "warn",
-};
-
 class SimplePoolExt implements NostrFetcherBase {
   #simplePool: SimplePool;
 
@@ -235,7 +232,7 @@ class SimplePoolExt implements NostrFetcherBase {
 
   #debugLogger: DebugLogger | undefined;
 
-  constructor(sp: SimplePool, options: Required<SimplePoolExtOptions>) {
+  constructor(sp: SimplePool, options: Required<NostrFetcherCommonOptions>) {
     this.#simplePool = sp;
     if (options.minLogLevel !== "none") {
       this.#debugLogger = new DebugLogger(options.minLogLevel);
@@ -398,10 +395,8 @@ class SimplePoolExt implements NostrFetcherBase {
  * const fetcher = NostrFetcher.withCustomPool(simplePoolAdapter(pool));
  * ```
  */
-export const simplePoolAdapter = (
-  pool: SimplePool,
-  options: SimplePoolExtOptions = {}
-): NostrFetcherBase => {
-  const finalOpts = { ...defaultExtOptions, ...options };
-  return new SimplePoolExt(pool, finalOpts);
+export const simplePoolAdapter = (pool: SimplePool): NostrFetcherBaseInitializer => {
+  return (commonOpts: Required<NostrFetcherCommonOptions>) => {
+    return new SimplePoolExt(pool, commonOpts);
+  };
 };

--- a/packages/nostr-fetch-kernel/src/fetcherBase.ts
+++ b/packages/nostr-fetch-kernel/src/fetcherBase.ts
@@ -1,3 +1,4 @@
+import { LogLevel } from "./debugLogger";
 import type { Filter, NostrEvent } from "./nostr";
 
 export type EnsureRelaysOptions = {
@@ -54,3 +55,26 @@ export interface NostrFetcherBase {
     options: FetchTillEoseOptions
   ): AsyncIterable<NostrEvent>;
 }
+
+/**
+ * Common options for `NostrFetcher` and all `NostrFetcherBase` implementations.
+ */
+export type NostrFetcherCommonOptions = {
+  minLogLevel?: LogLevel;
+};
+
+/**
+ * Default values of `NostrFetcherCommonOptions`.
+ */
+export const defaultFetcherCommonOptions: Required<NostrFetcherCommonOptions> = {
+  minLogLevel: "warn",
+};
+
+/**
+ * Type of initializer functions of `NostrFetcherBase`s.  Takes `NostrFetcherCommonOptions` and initialize a `NostrFetcherBase` impl.
+ *
+ * A "relay pool adapter" should return initializer function of this type.
+ */
+export type NostrFetcherBaseInitializer = (
+  commonOpts: Required<NostrFetcherCommonOptions>
+) => NostrFetcherBase;

--- a/packages/nostr-fetch-kernel/src/fetcherBase.ts
+++ b/packages/nostr-fetch-kernel/src/fetcherBase.ts
@@ -33,11 +33,6 @@ export interface NostrFetcherBase {
   ensureRelays(relayUrls: string[], options: EnsureRelaysOptions): Promise<string[]>;
 
   /**
-   * Cleans up all the internal states of the fetcher.
-   */
-  shutdown(): void;
-
-  /**
    * Fetches Nostr events matching `filters` from the relay specified by `relayUrl` until EOSE.
    *
    * The result is an `AsyncIterable` of Nostr events.
@@ -54,6 +49,11 @@ export interface NostrFetcherBase {
     filters: Filter[],
     options: FetchTillEoseOptions
   ): AsyncIterable<NostrEvent>;
+
+  /**
+   * Cleans up all the internal states of the fetcher.
+   */
+  shutdown(): void;
 }
 
 /**


### PR DESCRIPTION
Up until now, when you want to initialize `NostrFetcher` on top of an custom relay pool with options, you must pass same options twice as follows:

```ts
const fetcher = NostrFetcher.withCustomPool(xxxAdapter(pool, options), options)
```

This PR fixes this.

You can now do the same things with:

```ts
const fetcher = NostrFetcher.withCustomPool(xxxAdapter(pool), options)
```

`options` will be passed to the initailizer of the relay pool adapter as expected.