### PR TITLE
Reduct CloseEvent being passed to relay event lister

### DIFF
--- a/packages/nostr-fetch-kernel/src/relayTypes.ts
+++ b/packages/nostr-fetch-kernel/src/relayTypes.ts
@@ -2,8 +2,14 @@ import type { NostrEvent } from "./nostr";
 
 type Callback<E> = E extends void ? () => void : (ev: E) => void;
 
+export type WSCloseEvent = {
+  code: number;
+  reason: string;
+  wasClean: boolean | undefined; // optional since websocket-polyfill's CloseEvent doesn't have it
+};
+
 export type RelayConnectCb = Callback<void>;
-export type RelayDisconnectCb = Callback<CloseEvent | undefined>;
+export type RelayDisconnectCb = Callback<WSCloseEvent | undefined>;
 export type RelayNoticeCb = Callback<unknown>;
 export type RelayErrorCb = Callback<void>;
 

--- a/packages/nostr-fetch/src/relay.ts
+++ b/packages/nostr-fetch/src/relay.ts
@@ -1,4 +1,4 @@
-/* global WebSocket, CloseEvent, MessageEvent */
+/* global WebSocket, MessageEvent */
 import { verifyEventSig } from "@nostr-fetch/kernel/crypto";
 import type { C2RMessage, Filter, NostrEvent } from "@nostr-fetch/kernel/nostr";
 import { generateSubId, parseR2CMessage } from "@nostr-fetch/kernel/nostr";
@@ -16,6 +16,7 @@ import type {
   SubEventTypes,
   Subscription,
   SubscriptionOptions,
+  WSCloseEvent,
 } from "@nostr-fetch/kernel/relayTypes";
 
 export interface Relay {
@@ -139,8 +140,13 @@ class RelayImpl implements Relay {
         clearTimeout(timeout);
       };
 
-      ws.onclose = (e: CloseEvent) => {
-        this.#onDisconnect.forEach((cb) => cb(e));
+      ws.onclose = (e: WSCloseEvent) => {
+        const reducted = {
+          code: e.code,
+          reason: e.reason,
+          wasClean: e.wasClean,
+        };
+        this.#onDisconnect.forEach((cb) => cb(reducted));
       };
 
       ws.onmessage = (e: MessageEvent) => {


### PR DESCRIPTION
`websocket-pollyfill`'s `CloseEvent`s have too much data, so reduct it.