### PR TITLE
Allow specifying relay set per author in `fetchLatestEventsPerAuthor`

### DIFF
--- a/packages/examples/src/fetchLastPerAuthor.ts
+++ b/packages/examples/src/fetchLastPerAuthor.ts
@@ -29,9 +29,12 @@ const main = async () => {
     .map((t) => t[1] as string);
 
   // get profile (metadata) events for each followee
-  const profilePerAuthor = await fetcher.fetchLastEventPerAuthor(defaultRelays, followees, {
-    kinds: [eventKind.metadata],
-  });
+  const profilePerAuthor = await fetcher.fetchLastEventPerAuthor(
+    { authors: followees, relayUrls: defaultRelays },
+    {
+      kinds: [eventKind.metadata],
+    }
+  );
 
   // display the name in profile for each author
   console.log(`${"pubkey".padEnd(64, " ")} | name`);

--- a/packages/examples/src/fetchLatestPerAuthor.ts
+++ b/packages/examples/src/fetchLatestPerAuthor.ts
@@ -27,8 +27,7 @@ const main = async () => {
 
   // get latest 10 posts for each followee
   const latestPostsPerFollowee = await fetcher.fetchLatestEventsPerAuthor(
-    defaultRelays,
-    followees,
+    { authors: followees, relayUrls: defaultRelays },
     { kinds: [eventKind.text] },
     10
   );

--- a/packages/examples/src/outboxModel.ts
+++ b/packages/examples/src/outboxModel.ts
@@ -1,0 +1,90 @@
+import { setTimeout } from "node:timers/promises";
+import { eventKind, NostrEvent, NostrFetcher } from "nostr-fetch";
+import "websocket-polyfill";
+
+import { defaultRelays, getWriteRelaysFromEvent } from "./utils";
+
+if (process.argv.length <= 2) {
+  console.error("usage: outboxModel <hex pubkey>");
+  process.exit(1);
+}
+const pubkey = process.argv[2] as string;
+
+const fetcher = NostrFetcher.init({});
+
+// fetch pubkeys of followees from the latest kind 3 event
+const fetchFollowees = async (pubkey: string): Promise<string[]> => {
+  const ev = await fetcher.fetchLastEvent(defaultRelays, {
+    kinds: [eventKind.contacts],
+    authors: [pubkey],
+  });
+  if (ev === undefined) {
+    return [];
+  }
+  return ev.tags.filter((t) => t.length >= 2 && t[0] === "p").map((t) => t[1] as string);
+};
+
+// get write relays for each pubkeys
+const fetchWriteRelaysPerAuthors = async (authors: string[]): Promise<Map<string, string[]>> => {
+  const iter = await fetcher.fetchLastEventPerAuthor(
+    { authors, relayUrls: defaultRelays },
+    {
+      kinds: [eventKind.contacts, eventKind.relayList],
+    }
+  );
+  const res = new Map<string, string[]>();
+  for await (const { author, event: ev } of iter) {
+    if (ev !== undefined) {
+      const wrs = getWriteRelaysFromEvent(ev);
+      if (wrs.length > 0) {
+        res.set(author, wrs);
+      }
+    }
+  }
+  return res;
+};
+
+const main = async () => {
+  const followees = await fetchFollowees(pubkey);
+  if (followees.length === 0) {
+    console.error("contacts event (kind: 3) not found or you haven't followed any users");
+    return;
+  }
+
+  const writeRelaysPerFollowees = await fetchWriteRelaysPerAuthors(followees);
+  if (writeRelaysPerFollowees.size === 0) {
+    console.error("failed to fetch write relays for each followees");
+    return;
+  }
+
+  // get the last post for each followee
+  const lastPostsPerFollowee = await fetcher.fetchLastEventPerAuthor(writeRelaysPerFollowees, {
+    kinds: [eventKind.text],
+  });
+  for await (const { author, event: ev } of lastPostsPerFollowee) {
+    if (ev !== undefined) {
+      printPost(ev);
+    } else {
+      console.log(`post from author: ${author} not found`);
+    }
+  }
+};
+
+const printPost = (ev: NostrEvent) => {
+  console.log(
+    `last post from author: ${ev.pubkey} (${new Date(ev.created_at * 1000).toLocaleString()})`
+  );
+  console.log(ev.content);
+  console.log();
+};
+
+main()
+  .then(() => {
+    console.log("fin");
+    fetcher.shutdown();
+    return setTimeout(1000).then(process.exit(0));
+  })
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });

--- a/packages/examples/src/utils.ts
+++ b/packages/examples/src/utils.ts
@@ -1,3 +1,5 @@
+import { NostrEvent, eventKind } from "nostr-fetch";
+
 export const nHoursAgo = (hrs: number): number =>
   Math.floor((Date.now() - hrs * 60 * 60 * 1000) / 1000);
 
@@ -8,3 +10,39 @@ export const defaultRelays = [
   "wss://nostr-relay.nokotaro.com",
   "wss://relay.damus.io",
 ];
+
+export const getWriteRelaysFromEvent = (ev: NostrEvent): string[] => {
+  switch (ev.kind) {
+    case eventKind.contacts: {
+      let parsedContent: unknown;
+      try {
+        parsedContent = JSON.parse(ev.content);
+      } catch (err) {
+        return [];
+      }
+      const es = Object.entries(
+        parsedContent as Record<string, { read?: boolean; write?: boolean }>
+      );
+      return es.filter(([, usage]) => usage.write ?? false).map(([relay]) => relay);
+    }
+
+    case eventKind.relayList: {
+      return ev.tags
+        .filter((t) => {
+          if (t.length < 2 || t[0] !== "r") {
+            return false;
+          }
+          if (t.length === 2) {
+            // ["r", "relay-url"] -> read/write relays, keep
+            return true;
+          }
+          // ["r", "relay-url", "read|write"] -> keep "write" relays only
+          return t[2] === "write";
+        })
+        .map(([, relayUrl]) => relayUrl as string);
+    }
+
+    default:
+      throw Error("getRelaysToWriteFromEvent: unreachable!");
+  }
+};

--- a/packages/nostr-fetch-kernel/src/utils.ts
+++ b/packages/nostr-fetch-kernel/src/utils.ts
@@ -36,9 +36,22 @@ const dedup = <T>(items: T[]): T[] => {
 
 /**
  *  Normalizes each relay URL in `relayUrls`, then removes duplications.
+ *
+ *  This function also filters out malformed URLs.
  */
 export const normalizeRelayUrls = (relayUrls: string[]): string[] => {
-  return dedup(relayUrls.map((u) => normalizeRelayUrl(u)));
+  return dedup(
+    relayUrls
+      .filter((u) => {
+        try {
+          new URL(u);
+          return true;
+        } catch {
+          return false;
+        }
+      })
+      .map((u) => normalizeRelayUrl(u))
+  );
 };
 
 /**


### PR DESCRIPTION
The first argument of `fetchLatestEventsPerAuthor`/`fetchLastEventPerAuthor` now accepts either of:
- `{ authors: string[], relayUrls: string[] }`
- `Iterable<[string, string[]]>` (such as `Map<string, string[]>`)

In former case, the fetcher will use the same relay set (`relayUrls`) to fetch events for all `authors`. This behavior is the same as before.

In latter case, the fetcher will use separate relay set for each author, where first `string` value of elements of `Iterable` (or, key of `Map`) represents author's pubkey and second `string[]` value (or, value of `Map`) stands for relay set of the author.