### PR TITLE
Add an option to enable backpressure for `allEventsIterator`

### DIFF
--- a/packages/examples/src/backpressure.ts
+++ b/packages/examples/src/backpressure.ts
@@ -1,0 +1,39 @@
+import { setTimeout as delay } from "node:timers/promises";
+import { NostrFetcher, eventKind } from "nostr-fetch";
+import "websocket-polyfill";
+
+import { defaultRelays, nHoursAgo } from "./utils";
+
+const main = async () => {
+  // initialize fetcher based on nostr-relaypool's `RelayPool`
+  const fetcher = NostrFetcher.init();
+
+  // fetch all text events (kind: 1) posted in the last 3 hours from the relays
+  const eventsIter = await fetcher.allEventsIterator(
+    defaultRelays,
+    {
+      kinds: [eventKind.text],
+    },
+    {
+      since: nHoursAgo(3),
+    },
+    {
+      skipVerification: true,
+      enableBackpressure: true, // enabling backpressure mode!
+    }
+  );
+
+  for await (const ev of eventsIter) {
+    console.log(ev.content);
+    await delay(5); // simulating slow consumer
+  }
+
+  fetcher.shutdown();
+};
+
+main()
+  .then(() => console.log("fin"))
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });

--- a/packages/nostr-fetch-kernel/src/channel.ts
+++ b/packages/nostr-fetch-kernel/src/channel.ts
@@ -21,6 +21,8 @@ interface ChannelSender<T> {
   send(v: T): void;
   error(e: unknown): void;
   close(): void;
+
+  waitUntilDrained(): Promise<void>;
 }
 
 interface ChannelIter<T> {
@@ -33,6 +35,10 @@ class ChannelCloseSignal extends Error {
   }
 }
 
+type ChannelMakeOptions = {
+  highWaterMark?: number;
+};
+
 export class Channel<T> {
   #sendQ: (() => Promise<T>)[] = [];
   #recvQ: Deferred<T> | undefined;
@@ -40,11 +46,24 @@ export class Channel<T> {
 
   #iterAlreadyStarted = false;
 
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  private constructor() {}
+  // backpressure mode related
+  #highWaterMark: number | undefined;
+  #drainWaiter: Deferred<void> | undefined;
 
-  static make<T>(): [ChannelSender<T>, ChannelIter<T>] {
-    const c = new Channel<T>();
+  private constructor({ highWaterMark = undefined }: ChannelMakeOptions) {
+    this.#highWaterMark = highWaterMark;
+  }
+
+  /**
+   * Makes an asyncronous channel.
+   *
+   * Return a pair of a sender endpoint and an iterator which iterate over items sent to the channel.
+   *
+   * Specifying `highWaterMark` option enables the "backpressure mode".
+   * In this mode, a sender can wait until internal queue is free enough.
+   */
+  static make<T>(options?: ChannelMakeOptions): [ChannelSender<T>, ChannelIter<T>] {
+    const c = new Channel<T>(options ?? {});
     return [c as ChannelSender<T>, c as ChannelIter<T>];
   }
 
@@ -84,13 +103,39 @@ export class Channel<T> {
     }
   }
 
+  // checks if sendQ's "water level" is higher than highWaterMark
+  private get isSendQOverflowed(): boolean {
+    return this.#highWaterMark !== undefined && this.#sendQ.length > this.#highWaterMark;
+  }
+
+  waitUntilDrained(): Promise<void> {
+    if (this.#drainWaiter !== undefined) {
+      return this.#drainWaiter.promise;
+    }
+
+    if (!this.isSendQOverflowed) {
+      return Promise.resolve();
+    }
+    // sendQ have overflowed -> wait until drained
+    this.#drainWaiter = new Deferred();
+    return this.#drainWaiter.promise;
+  }
+
   private get isCompleted(): boolean {
     return this.#closed && this.#sendQ.length === 0;
   }
 
   private recv(): () => Promise<T> {
     if (this.#sendQ.length > 0) {
-      return this.#sendQ.shift() as () => Promise<T>;
+      const next = this.#sendQ.shift() as () => Promise<T>;
+
+      if (this.#drainWaiter !== undefined && !this.isSendQOverflowed) {
+        // notify to sender that sendQ have been drained enough
+        this.#drainWaiter.resolve();
+        this.#drainWaiter = undefined;
+      }
+
+      return next;
     }
     if (this.#recvQ !== undefined) {
       return () => Promise.reject(Error("Double receive is not allowed"));

--- a/packages/nostr-fetch-kernel/src/channel.ts
+++ b/packages/nostr-fetch-kernel/src/channel.ts
@@ -36,7 +36,7 @@ class ChannelCloseSignal extends Error {
 }
 
 type ChannelMakeOptions = {
-  highWaterMark?: number;
+  highWaterMark?: number | undefined;
 };
 
 export class Channel<T> {


### PR DESCRIPTION
New option `enableBackpressure` which enables "backpressure mode" of `allEventsIterator`.

This feature would be useful under situations where the consumer of events is slower than the producer (the fetcher).

resolves #27.