### PR TITLE
Docs: add notes about ignored options on adapter's docs

### DIFF
--- a/packages/adapter-ndk/src/index.ts
+++ b/packages/adapter-ndk/src/index.ts
@@ -198,6 +198,9 @@ class NDKAdapter implements NostrFetcherBase {
 /**
  * Wraps an NDK instance, allowing it to interoperate with nostr-fetch.
  *
+ * Note: if you use this adapter, `skipVerification` option is ignored and it always behaves as if `false` is specified (always verify signatures).
+ * Moreover, `reduceVerification` option becomes meaningless with this adapter.
+ *
  * @example
  * ```
  * import NDK from '@nostr-dev-kit/ndk';

--- a/packages/adapter-nostr-relaypool/src/index.ts
+++ b/packages/adapter-nostr-relaypool/src/index.ts
@@ -255,6 +255,11 @@ class NRTPoolAdapter implements NostrFetcherBase {
 /**
  * Wraps a nostr-relaypool's `RelayPool`, allowing it to interoperate with nostr-fetch.
  *
+ * Note: if you use this adapter, `skipVerification` option is ignored.
+ * You can still configure whether verify signatures or not on initializing `RelayPool`, but you can't configure about it "per fetch" basis.
+ *
+ * If your `RelayPool` is initialized with `skipVerification: false`, `reduceVerification` option becomes meaningless.
+ *
  * @example
  * ```
  * import { RelayPool } from 'nostr-relaypool';


### PR DESCRIPTION
Several relay pool impls don't expose means to configure `skipVerification` option per-subscription basis.  In that case, we have no choice but to ignore `skipVerification` in the passed fetch option.

In this PR, notes about this behavior are added to doc comment for adapters.