### PR TITLE
Export `NostrFetchError`

### DIFF
--- a/packages/adapter-ndk/tsconfig.build.json
+++ b/packages/adapter-ndk/tsconfig.build.json
@@ -1,15 +1,10 @@
 {
+  "extends": "./tsconfig.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "lib": ["dom", "dom.iterable", "esnext", "webworker", "scripthost"],
+    "noEmit": false,
     "declaration": true,
     "declarationDir": "./dist",
     "declarationMap": true,
-    "strict": true,
-    "moduleResolution": "node",
-    "esModuleInterop": true,
-    "skipLibCheck": true,
     "emitDeclarationOnly": true,
   },
   "exclude": ["src/**/*.spec.ts"]

--- a/packages/adapter-nostr-relaypool/tsconfig.build.json
+++ b/packages/adapter-nostr-relaypool/tsconfig.build.json
@@ -1,16 +1,11 @@
 {
+  "extends": "./tsconfig.lint.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "lib": ["dom", "dom.iterable", "esnext", "webworker", "scripthost"],
+    "noEmit": false,
     "declaration": true,
     "declarationDir": "./dist",
     "declarationMap": true,
-    "strict": true,
-    "moduleResolution": "node",
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "emitDeclarationOnly": true,
+    "emitDeclarationOnly": true
   },
   "exclude": ["src/**/*.spec.ts"]
 }

--- a/packages/nostr-fetch/src/fetcher.spec.ts
+++ b/packages/nostr-fetch/src/fetcher.spec.ts
@@ -284,7 +284,7 @@ describe.concurrent("NostrFetcher", () => {
         ["wss://healthy", "wss://slow-to-return-events"],
         {},
         {},
-        { abortSubBeforeEoseTimeoutMs: 500 }
+        { abortSubBeforeEoseTimeoutMs: 100 }
       );
       const evs = await collectAsyncIter(evIter);
       expect(evs.length).toBe(10);

--- a/packages/nostr-fetch/src/index.ts
+++ b/packages/nostr-fetch/src/index.ts
@@ -1,3 +1,4 @@
 export { NostrEvent, eventKind } from "@nostr-fetch/kernel/nostr";
 export { normalizeRelayUrl, normalizeRelayUrls } from "@nostr-fetch/kernel/utils";
 export * from "./fetcher";
+export { NostrFetchError } from "./fetcherHelper";

--- a/packages/nostr-fetch/tsconfig.build.json
+++ b/packages/nostr-fetch/tsconfig.build.json
@@ -7,5 +7,5 @@
     "declarationMap": true,
     "emitDeclarationOnly": true,
   },
-  "exclude": ["src/**/*.spec.ts"]
+  "exclude": ["src/**/*.spec.ts", "src/testutil/**/*.ts"]
 }


### PR DESCRIPTION
resolves #37.

also fixes build configurations to exclude unnecessary files from distributions.