### PR TITLE
Fixups before 0.10

### DIFF
--- a/packages/adapter-ndk/src/adapter.spec.ts
+++ b/packages/adapter-ndk/src/adapter.spec.ts
@@ -1,4 +1,4 @@
-import { FetchTillEoseOptions, NostrFetcherBase } from "@nostr-fetch/kernel/fetcherBase";
+import { FetchTillEoseOptions, NostrFetcherBackend } from "@nostr-fetch/kernel/fetcherBackend";
 import { setupMockRelayServer } from "@nostr-fetch/testutil/mockRelayServer";
 import { NDKAdapter } from "./adapter";
 
@@ -36,25 +36,25 @@ describe("NDKAdapter", () => {
     };
 
     const url = "ws://localhost:8000/";
-    let fetcherBase: NostrFetcherBase;
+    let backend: NostrFetcherBackend;
     let wsServer: WS;
 
     beforeEach(async () => {
       wsServer = new WS(url, { jsonProtocol: true });
 
       const ndk = new NDK();
-      fetcherBase = new NDKAdapter(ndk, { minLogLevel: "none" });
+      backend = new NDKAdapter(ndk, { minLogLevel: "none" });
     });
     afterEach(() => {
-      fetcherBase.shutdown(); // if we omit this line, a strange error occurs on the next line...
+      backend.shutdown(); // if we omit this line, a strange error occurs on the next line...
       WS.clean();
     });
 
     test("fetches events until EOSE", async () => {
       setupMockRelayServer(wsServer, [{ type: "events", eventsSpec: { content: "test", n: 10 } }]);
 
-      await fetcherBase.ensureRelays([url], { connectTimeoutMs: 1000 });
-      const iter = fetcherBase.fetchTillEose(url, {}, defaultOpts);
+      await backend.ensureRelays([url], { connectTimeoutMs: 1000 });
+      const iter = backend.fetchTillEose(url, {}, defaultOpts);
       const evs = await collectAsyncIter(iter);
       expect(evs.length).toBe(10);
 
@@ -69,8 +69,8 @@ describe("NDKAdapter", () => {
         { type: "events", eventsSpec: { content: "after notice", n: 1 } },
       ]);
 
-      await fetcherBase.ensureRelays([url], { connectTimeoutMs: 1000 });
-      const iter = fetcherBase.fetchTillEose(url, {}, defaultOpts);
+      await backend.ensureRelays([url], { connectTimeoutMs: 1000 });
+      const iter = backend.fetchTillEose(url, {}, defaultOpts);
       const evs = await collectAsyncIter(iter);
       expect(evs.length).toBe(9);
 
@@ -87,8 +87,8 @@ describe("NDKAdapter", () => {
         { type: "events", eventsSpec: { content: "deleyed", n: 1 } },
       ]);
 
-      await fetcherBase.ensureRelays([url], { connectTimeoutMs: 1000 });
-      const iter = fetcherBase.fetchTillEose(
+      await backend.ensureRelays([url], { connectTimeoutMs: 1000 });
+      const iter = backend.fetchTillEose(
         url,
         {},
         optsWithDefault({ abortSubBeforeEoseTimeoutMs: 1000 })
@@ -110,8 +110,8 @@ describe("NDKAdapter", () => {
         ac.abort();
       }, 500);
 
-      await fetcherBase.ensureRelays([url], { connectTimeoutMs: 1000 });
-      const iter = fetcherBase.fetchTillEose(url, {}, optsWithDefault({ abortSignal: ac.signal }));
+      await backend.ensureRelays([url], { connectTimeoutMs: 1000 });
+      const iter = backend.fetchTillEose(url, {}, optsWithDefault({ abortSignal: ac.signal }));
       const evs = await collectAsyncIter(iter);
       expect(evs.length).toBeLessThan(10);
 

--- a/packages/adapter-ndk/src/adapter.ts
+++ b/packages/adapter-ndk/src/adapter.ts
@@ -3,9 +3,9 @@ import { DebugLogger } from "@nostr-fetch/kernel/debugLogger";
 import type {
   EnsureRelaysOptions,
   FetchTillEoseOptions,
-  NostrFetcherBase,
+  NostrFetcherBackend,
   NostrFetcherCommonOptions,
-} from "@nostr-fetch/kernel/fetcherBase";
+} from "@nostr-fetch/kernel/fetcherBackend";
 import type { Filter, NostrEvent } from "@nostr-fetch/kernel/nostr";
 import {
   emptyAsyncGen,
@@ -17,7 +17,7 @@ import {
 import type NDK from "@nostr-dev-kit/ndk";
 import { NDKEvent, NDKRelay, NDKRelaySet, NDKRelayStatus } from "@nostr-dev-kit/ndk";
 
-export class NDKAdapter implements NostrFetcherBase {
+export class NDKAdapter implements NostrFetcherBackend {
   #ndk: NDK;
   #implicitRelays: Map<string, NDKRelay> = new Map();
 

--- a/packages/adapter-ndk/src/index.ts
+++ b/packages/adapter-ndk/src/index.ts
@@ -2,9 +2,9 @@ import { NDKAdapter } from "./adapter";
 
 import type NDK from "@nostr-dev-kit/ndk";
 import type {
-  NostrFetcherBaseInitializer,
+  NostrFetcherBackendInitializer,
   NostrFetcherCommonOptions,
-} from "@nostr-fetch/kernel/fetcherBase";
+} from "@nostr-fetch/kernel/fetcherBackend";
 
 /**
  * Wraps an NDK instance, allowing it to interoperate with nostr-fetch.
@@ -33,7 +33,7 @@ import type {
  * }
  * ```
  */
-export const ndkAdapter = (ndk: NDK): NostrFetcherBaseInitializer => {
+export const ndkAdapter = (ndk: NDK): NostrFetcherBackendInitializer => {
   return (commonOpts: Required<NostrFetcherCommonOptions>) => {
     return new NDKAdapter(ndk, commonOpts);
   };

--- a/packages/adapter-nostr-relaypool/src/adapter.spec.ts
+++ b/packages/adapter-nostr-relaypool/src/adapter.spec.ts
@@ -1,4 +1,4 @@
-import { FetchTillEoseOptions, NostrFetcherBase } from "@nostr-fetch/kernel/fetcherBase";
+import { FetchTillEoseOptions, NostrFetcherBackend } from "@nostr-fetch/kernel/fetcherBackend";
 import { setupMockRelayServer } from "@nostr-fetch/testutil/mockRelayServer";
 import { NRTPoolAdapter } from "./adapter";
 
@@ -36,14 +36,14 @@ describe.skip("NRTPoolAdapter", () => {
     };
 
     const url = "ws://localhost:8000/";
-    let fetcherBase: NostrFetcherBase;
+    let backend: NostrFetcherBackend;
     let wsServer: WS;
 
     beforeEach(async () => {
       wsServer = new WS(url, { jsonProtocol: true });
 
       const relayPool = new RelayPool();
-      fetcherBase = new NRTPoolAdapter(relayPool, { minLogLevel: "none" });
+      backend = new NRTPoolAdapter(relayPool, { minLogLevel: "none" });
     });
     afterEach(() => {
       WS.clean();
@@ -52,8 +52,8 @@ describe.skip("NRTPoolAdapter", () => {
     test("fetches events until EOSE", async () => {
       setupMockRelayServer(wsServer, [{ type: "events", eventsSpec: { content: "test", n: 10 } }]);
 
-      await fetcherBase.ensureRelays([url], { connectTimeoutMs: 1000 });
-      const iter = fetcherBase.fetchTillEose(url, {}, defaultOpts);
+      await backend.ensureRelays([url], { connectTimeoutMs: 1000 });
+      const iter = backend.fetchTillEose(url, {}, defaultOpts);
       const evs = await collectAsyncIter(iter);
       expect(evs.length).toBe(10);
 
@@ -68,8 +68,8 @@ describe.skip("NRTPoolAdapter", () => {
         { type: "events", eventsSpec: { content: "after notice", n: 1 } },
       ]);
 
-      await fetcherBase.ensureRelays([url], { connectTimeoutMs: 1000 });
-      const iter = fetcherBase.fetchTillEose(url, {}, defaultOpts);
+      await backend.ensureRelays([url], { connectTimeoutMs: 1000 });
+      const iter = backend.fetchTillEose(url, {}, defaultOpts);
       const evs = await collectAsyncIter(iter);
       expect(evs.length).toBe(9);
 
@@ -84,8 +84,8 @@ describe.skip("NRTPoolAdapter", () => {
         { type: "error" },
       ]);
 
-      await fetcherBase.ensureRelays([url], { connectTimeoutMs: 1000 });
-      const iter = fetcherBase.fetchTillEose(url, {}, defaultOpts);
+      await backend.ensureRelays([url], { connectTimeoutMs: 1000 });
+      const iter = backend.fetchTillEose(url, {}, defaultOpts);
       const evs = await collectAsyncIter(iter);
       expect(evs.length).toBe(5);
 
@@ -100,8 +100,8 @@ describe.skip("NRTPoolAdapter", () => {
         { type: "events", eventsSpec: { content: "deleyed", n: 1 } },
       ]);
 
-      await fetcherBase.ensureRelays([url], { connectTimeoutMs: 1000 });
-      const iter = fetcherBase.fetchTillEose(
+      await backend.ensureRelays([url], { connectTimeoutMs: 1000 });
+      const iter = backend.fetchTillEose(
         url,
         {},
         optsWithDefault({ abortSubBeforeEoseTimeoutMs: 1000 })
@@ -123,8 +123,8 @@ describe.skip("NRTPoolAdapter", () => {
         ac.abort();
       }, 500);
 
-      await fetcherBase.ensureRelays([url], { connectTimeoutMs: 1000 });
-      const iter = fetcherBase.fetchTillEose(url, {}, optsWithDefault({ abortSignal: ac.signal }));
+      await backend.ensureRelays([url], { connectTimeoutMs: 1000 });
+      const iter = backend.fetchTillEose(url, {}, optsWithDefault({ abortSignal: ac.signal }));
       const evs = await collectAsyncIter(iter);
       expect(evs.length).toBeLessThan(10);
 

--- a/packages/adapter-nostr-relaypool/src/adapter.ts
+++ b/packages/adapter-nostr-relaypool/src/adapter.ts
@@ -3,9 +3,9 @@ import { DebugLogger } from "@nostr-fetch/kernel/debugLogger";
 import type {
   EnsureRelaysOptions,
   FetchTillEoseOptions,
-  NostrFetcherBase,
+  NostrFetcherBackend,
   NostrFetcherCommonOptions,
-} from "@nostr-fetch/kernel/fetcherBase";
+} from "@nostr-fetch/kernel/fetcherBackend";
 import type { Filter, NostrEvent } from "@nostr-fetch/kernel/nostr";
 import { normalizeRelayUrls, withTimeout } from "@nostr-fetch/kernel/utils";
 
@@ -28,7 +28,7 @@ type NRTPoolListenersTable = {
   [E in keyof NRTPoolEventCbs]: Map<string, NRTPoolEventCbs[E]>;
 };
 
-export class NRTPoolAdapter implements NostrFetcherBase {
+export class NRTPoolAdapter implements NostrFetcherBackend {
   #pool: RelayPool;
 
   // we need to hold notice/error listeners here since we can't remove them from RelayPool.

--- a/packages/adapter-nostr-relaypool/src/index.ts
+++ b/packages/adapter-nostr-relaypool/src/index.ts
@@ -1,9 +1,9 @@
 import { NRTPoolAdapter } from "./adapter";
 
 import type {
-  NostrFetcherBaseInitializer,
+  NostrFetcherBackendInitializer,
   NostrFetcherCommonOptions,
-} from "@nostr-fetch/kernel/fetcherBase";
+} from "@nostr-fetch/kernel/fetcherBackend";
 import type { RelayPool } from "nostr-relaypool";
 
 /**
@@ -24,7 +24,7 @@ import type { RelayPool } from "nostr-relaypool";
  * const fetcher = NostrFetcher.withCustomPool(relayPoolAdapter(pool));
  * ```
  */
-export const relayPoolAdapter = (pool: RelayPool): NostrFetcherBaseInitializer => {
+export const relayPoolAdapter = (pool: RelayPool): NostrFetcherBackendInitializer => {
   return (commonOpts: Required<NostrFetcherCommonOptions>) => {
     return new NRTPoolAdapter(pool, commonOpts);
   };

--- a/packages/adapter-nostr-relaypool/tsconfig.json
+++ b/packages/adapter-nostr-relaypool/tsconfig.json
@@ -9,5 +9,4 @@
     "noEmit": true,
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["src/**/*.spec.ts"]
 }

--- a/packages/adapter-nostr-relaypool/tsconfig.lint.json
+++ b/packages/adapter-nostr-relaypool/tsconfig.lint.json
@@ -7,7 +7,8 @@
     "strict": true,
     "moduleResolution": "node",
     "esModuleInterop": true,
-    "skipLibCheck": true,
+    "skipLibCheck": true
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts"]
 }

--- a/packages/adapter-nostr-tools/src/adapter.spec.ts
+++ b/packages/adapter-nostr-tools/src/adapter.spec.ts
@@ -1,4 +1,4 @@
-import { FetchTillEoseOptions, NostrFetcherBase } from "@nostr-fetch/kernel/fetcherBase";
+import { FetchTillEoseOptions, NostrFetcherBackend } from "@nostr-fetch/kernel/fetcherBackend";
 import { setupMockRelayServer } from "@nostr-fetch/testutil/mockRelayServer";
 import { SimplePoolExt } from "./adapter";
 
@@ -35,14 +35,14 @@ describe("SimplePoolExt", () => {
     };
 
     const url = "ws://localhost:8000";
-    let fetcherBase: NostrFetcherBase;
+    let backend: NostrFetcherBackend;
     let wsServer: WS;
 
     beforeEach(async () => {
       wsServer = new WS(url, { jsonProtocol: true });
 
       const simplePool = new SimplePool();
-      fetcherBase = new SimplePoolExt(simplePool, { minLogLevel: "none" });
+      backend = new SimplePoolExt(simplePool, { minLogLevel: "none" });
     });
     afterEach(() => {
       WS.clean();
@@ -51,8 +51,8 @@ describe("SimplePoolExt", () => {
     test("fetches events until EOSE", async () => {
       setupMockRelayServer(wsServer, [{ type: "events", eventsSpec: { content: "test", n: 10 } }]);
 
-      await fetcherBase.ensureRelays([url], { connectTimeoutMs: 1000 });
-      const iter = fetcherBase.fetchTillEose(url, {}, defaultOpts);
+      await backend.ensureRelays([url], { connectTimeoutMs: 1000 });
+      const iter = backend.fetchTillEose(url, {}, defaultOpts);
       const evs = await collectAsyncIter(iter);
       expect(evs.length).toBe(10);
 
@@ -67,8 +67,8 @@ describe("SimplePoolExt", () => {
         { type: "events", eventsSpec: { content: "after notice", n: 1 } },
       ]);
 
-      await fetcherBase.ensureRelays([url], { connectTimeoutMs: 1000 });
-      const iter = fetcherBase.fetchTillEose(url, {}, defaultOpts);
+      await backend.ensureRelays([url], { connectTimeoutMs: 1000 });
+      const iter = backend.fetchTillEose(url, {}, defaultOpts);
       const evs = await collectAsyncIter(iter);
       expect(evs.length).toBe(9);
 
@@ -83,8 +83,8 @@ describe("SimplePoolExt", () => {
         { type: "error" },
       ]);
 
-      await fetcherBase.ensureRelays([url], { connectTimeoutMs: 1000 });
-      const iter = fetcherBase.fetchTillEose(url, {}, defaultOpts);
+      await backend.ensureRelays([url], { connectTimeoutMs: 1000 });
+      const iter = backend.fetchTillEose(url, {}, defaultOpts);
       const evs = await collectAsyncIter(iter);
       expect(evs.length).toBe(5);
 
@@ -99,8 +99,8 @@ describe("SimplePoolExt", () => {
         { type: "events", eventsSpec: { content: "deleyed", n: 1 } },
       ]);
 
-      await fetcherBase.ensureRelays([url], { connectTimeoutMs: 1000 });
-      const iter = fetcherBase.fetchTillEose(
+      await backend.ensureRelays([url], { connectTimeoutMs: 1000 });
+      const iter = backend.fetchTillEose(
         url,
         {},
         optsWithDefault({ abortSubBeforeEoseTimeoutMs: 1000 })
@@ -122,8 +122,8 @@ describe("SimplePoolExt", () => {
         ac.abort();
       }, 500);
 
-      await fetcherBase.ensureRelays([url], { connectTimeoutMs: 1000 });
-      const iter = fetcherBase.fetchTillEose(url, {}, optsWithDefault({ abortSignal: ac.signal }));
+      await backend.ensureRelays([url], { connectTimeoutMs: 1000 });
+      const iter = backend.fetchTillEose(url, {}, optsWithDefault({ abortSignal: ac.signal }));
       const evs = await collectAsyncIter(iter);
       expect(evs.length).toBeLessThan(10);
 
@@ -137,8 +137,8 @@ describe("SimplePoolExt", () => {
         { type: "events", eventsSpec: { content: "invalid", invalidSig: true } },
       ]);
 
-      await fetcherBase.ensureRelays([url], { connectTimeoutMs: 1000 });
-      const iter = fetcherBase.fetchTillEose(url, {}, optsWithDefault({ skipVerification: true }));
+      await backend.ensureRelays([url], { connectTimeoutMs: 1000 });
+      const iter = backend.fetchTillEose(url, {}, optsWithDefault({ skipVerification: true }));
       const evs = await collectAsyncIter(iter);
       expect(evs.length).toBe(11);
 

--- a/packages/adapter-nostr-tools/src/adapter.ts
+++ b/packages/adapter-nostr-tools/src/adapter.ts
@@ -3,9 +3,9 @@ import { DebugLogger } from "@nostr-fetch/kernel/debugLogger";
 import type {
   EnsureRelaysOptions,
   FetchTillEoseOptions,
-  NostrFetcherBase,
+  NostrFetcherBackend,
   NostrFetcherCommonOptions,
-} from "@nostr-fetch/kernel/fetcherBase";
+} from "@nostr-fetch/kernel/fetcherBackend";
 import { NostrEvent, type Filter } from "@nostr-fetch/kernel/nostr";
 import {
   emptyAsyncGen,
@@ -16,7 +16,7 @@ import {
 
 import type { SimplePool, Relay as ToolsRelay } from "nostr-tools";
 
-export class SimplePoolExt implements NostrFetcherBase {
+export class SimplePoolExt implements NostrFetcherBackend {
   #simplePool: SimplePool;
 
   // storing refs to `ToolsRelay`s to allow to take out them synchronously.

--- a/packages/adapter-nostr-tools/src/index.ts
+++ b/packages/adapter-nostr-tools/src/index.ts
@@ -1,9 +1,9 @@
 import { SimplePoolExt } from "./adapter";
 
 import type {
-  NostrFetcherBaseInitializer,
+  NostrFetcherBackendInitializer,
   NostrFetcherCommonOptions,
-} from "@nostr-fetch/kernel/fetcherBase";
+} from "@nostr-fetch/kernel/fetcherBackend";
 import type { SimplePool } from "nostr-tools";
 
 /**
@@ -19,7 +19,7 @@ import type { SimplePool } from "nostr-tools";
  * const fetcher = NostrFetcher.withCustomPool(simplePoolAdapter(pool));
  * ```
  */
-export const simplePoolAdapter = (pool: SimplePool): NostrFetcherBaseInitializer => {
+export const simplePoolAdapter = (pool: SimplePool): NostrFetcherBackendInitializer => {
   return (commonOpts: Required<NostrFetcherCommonOptions>) => {
     return new SimplePoolExt(pool, commonOpts);
   };

--- a/packages/nostr-fetch-kernel/src/fetcherBackend.ts
+++ b/packages/nostr-fetch-kernel/src/fetcherBackend.ts
@@ -18,7 +18,7 @@ export type FetchTillEoseOptions = {
  *
  * `NostrFetcher` implements its functions on top of this.
  */
-export interface NostrFetcherBase {
+export interface NostrFetcherBackend {
   /**
    * Ensures connections to the relays prior to an event subscription.
    *
@@ -57,7 +57,7 @@ export interface NostrFetcherBase {
 }
 
 /**
- * Common options for `NostrFetcher` and all `NostrFetcherBase` implementations.
+ * Common options for `NostrFetcher` and all `NostrFetcherBackend` implementations.
  */
 export type NostrFetcherCommonOptions = {
   minLogLevel?: LogLevel;
@@ -71,10 +71,10 @@ export const defaultFetcherCommonOptions: Required<NostrFetcherCommonOptions> = 
 };
 
 /**
- * Type of initializer functions of `NostrFetcherBase`s.  Takes `NostrFetcherCommonOptions` and initialize a `NostrFetcherBase` impl.
+ * Type of initializer functions of `NostrFetcherBackend`s.  Takes `NostrFetcherCommonOptions` and initialize a `NostrFetcherBackend` impl.
  *
  * A "relay pool adapter" should return initializer function of this type.
  */
-export type NostrFetcherBaseInitializer = (
+export type NostrFetcherBackendInitializer = (
   commonOpts: Required<NostrFetcherCommonOptions>
-) => NostrFetcherBase;
+) => NostrFetcherBackend;

--- a/packages/nostr-fetch-kernel/src/nostr.ts
+++ b/packages/nostr-fetch-kernel/src/nostr.ts
@@ -67,7 +67,7 @@ export type Filter = {
   until?: number;
   limit?: number;
   search?: string;
-  [tag: `#${string}`]: string[] | undefined;
+  [tag: `#${string}`]: string[];
 };
 
 // client to relay messages

--- a/packages/nostr-fetch-kernel/src/nostr.ts
+++ b/packages/nostr-fetch-kernel/src/nostr.ts
@@ -62,7 +62,7 @@ export type Filter = {
   until?: number;
   limit?: number;
   search?: string;
-  [key: `#${string}`]: string[];
+  [tag: `#${string}`]: string[] | undefined;
 };
 
 // client to relay messages

--- a/packages/nostr-fetch-kernel/src/nostr.ts
+++ b/packages/nostr-fetch-kernel/src/nostr.ts
@@ -24,6 +24,7 @@ export const eventKind = {
   repost: 6,
   reaction: 7,
   badgeAward: 8,
+  genericRepost: 16,
   channelCreation: 40,
   channelMetadata: 41,
   channelMessage: 42,
@@ -31,6 +32,7 @@ export const eventKind = {
   channelMuteUser: 44,
   fileMetadata: 1063,
   report: 1984,
+  label: 1985,
   zapRequest: 9734,
   zap: 9735,
   muteList: 10000,
@@ -41,6 +43,7 @@ export const eventKind = {
   walletRequest: 23194,
   walletResponse: 23195,
   nostrConnect: 24133,
+  httpAuth: 27235,
   categorizedPeopleList: 30000,
   categorizedBookmarkList: 30001,
   profileBadges: 30008,
@@ -49,6 +52,8 @@ export const eventKind = {
   marketplaceProduct: 30018,
   article: 30023,
   appSpecificData: 30078,
+  handlerRecommendation: 31989,
+  handlerInformation: 31990,
 } as const;
 
 /**

--- a/packages/nostr-fetch/src/fetcherBackend.ts
+++ b/packages/nostr-fetch/src/fetcherBackend.ts
@@ -2,9 +2,9 @@ import { Channel } from "@nostr-fetch/kernel/channel";
 import type {
   EnsureRelaysOptions,
   FetchTillEoseOptions,
-  NostrFetcherBase,
+  NostrFetcherBackend,
   NostrFetcherCommonOptions,
-} from "@nostr-fetch/kernel/fetcherBase";
+} from "@nostr-fetch/kernel/fetcherBackend";
 import type { Filter, NostrEvent } from "@nostr-fetch/kernel/nostr";
 import { emptyAsyncGen } from "@nostr-fetch/kernel/utils";
 
@@ -12,9 +12,9 @@ import { DebugLogger } from "@nostr-fetch/kernel/debugLogger";
 import { RelayPool, initRelayPool } from "./relayPool";
 
 /**
- * Default implementation of `NostrFetchBase`.
+ * Default implementation of `NostrFetchBackend`.
  */
-export class DefaultFetcherBase implements NostrFetcherBase {
+export class DefaultFetcherBackend implements NostrFetcherBackend {
   #relayPool: RelayPool;
   #debugLogger: DebugLogger | undefined;
 

--- a/packages/nostr-fetch/src/fetcherHelper.ts
+++ b/packages/nostr-fetch/src/fetcherHelper.ts
@@ -1,5 +1,5 @@
 import { DebugLogger } from "@nostr-fetch/kernel/debugLogger";
-import { NostrFetcherCommonOptions } from "@nostr-fetch/kernel/fetcherBase";
+import { NostrFetcherCommonOptions } from "@nostr-fetch/kernel/fetcherBackend";
 import { NostrEvent, querySupportedNips } from "@nostr-fetch/kernel/nostr";
 
 /**

--- a/packages/nostr-fetch/src/testutil/fakedFetcher.ts
+++ b/packages/nostr-fetch/src/testutil/fakedFetcher.ts
@@ -3,9 +3,9 @@ import { verifyEventSig } from "@nostr-fetch/kernel/crypto";
 import {
   EnsureRelaysOptions,
   FetchTillEoseOptions,
-  NostrFetcherBase,
+  NostrFetcherBackend,
   NostrFetcherCommonOptions,
-} from "@nostr-fetch/kernel/fetcherBase";
+} from "@nostr-fetch/kernel/fetcherBackend";
 import { Filter, NostrEvent, generateSubId } from "@nostr-fetch/kernel/nostr";
 import {
   emptyAsyncGen,
@@ -20,7 +20,7 @@ import { RelayCapabilityChecker, createdAtDesc } from "../fetcherHelper";
 import { setTimeout as delay } from "node:timers/promises";
 
 /**
- * Faking NostrFetcherBase and RelayCapabilityChecker for testing NostrFetcher
+ * Faking NostrFetcherBackend and RelayCapabilityChecker for testing NostrFetcher
  */
 
 export type FakeRelaySpec = {
@@ -143,7 +143,7 @@ class FakeRelay {
   }
 }
 
-class FakeFetcherBase implements NostrFetcherBase {
+class FakeFetcherBackend implements NostrFetcherBackend {
   #mapFakeRelay: Map<string, FakeRelay> = new Map();
 
   #calledShutdown = false;
@@ -256,8 +256,8 @@ export class FakedFetcherBuilder {
   }
 
   buildFetcher(opts: NostrFetcherCommonOptions = {}): NostrFetcher {
-    const base = () => new FakeFetcherBase(this.#mapFakeRelaySpec);
+    const backend = () => new FakeFetcherBackend(this.#mapFakeRelaySpec);
     const capChecker = () => new FakeRelayCapChecker(this.#mapFakeRelaySpec);
-    return NostrFetcher.withCustomPool(base, opts, capChecker);
+    return NostrFetcher.withCustomPool(backend, opts, capChecker);
   }
 }


### PR DESCRIPTION
resolves #43.

> make tag query field in Filter optional (add undefined)

Found that this change makes `Filter` incompatible with `nostr-tools` version of `Filter`, so it is reverted.