### PR TITLE
Add the `withSeenOn` option to fetchers

### DIFF
--- a/packages/examples/src/seenOn.ts
+++ b/packages/examples/src/seenOn.ts
@@ -1,0 +1,34 @@
+import { eventKind, NostrFetcher } from "nostr-fetch";
+import "websocket-polyfill";
+
+import { defaultRelays } from "./utils";
+
+const main = async () => {
+  const fetcher = NostrFetcher.init();
+
+  // fetch the latest 100 text events (kind: 1) from the relays, with "seen on" information
+  const latestPosts = await fetcher.fetchLatestEvents(
+    defaultRelays,
+    {
+      kinds: [eventKind.text],
+    },
+    100,
+    { withSeenOn: false }
+  );
+
+  console.log(`got ${latestPosts.length} events`);
+  for (const e of latestPosts) {
+    console.log(e.content);
+    console.log("seen on:", e.seenOn);
+    console.log();
+  }
+
+  fetcher.shutdown();
+};
+
+main()
+  .then(() => console.log("fin"))
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });

--- a/packages/nostr-fetch/src/fetcherHelper.spec.ts
+++ b/packages/nostr-fetch/src/fetcherHelper.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { EventBuckets, KeyRelayMatrix } from "./fetcherHelper";
+import { EventBuckets, KeyRelayMatrix, initSeenEvents } from "./fetcherHelper";
 
 const dummyEvent = (id: string) => {
   return {
@@ -104,5 +104,41 @@ describe("KeyRelayMatrix", () => {
     expect(matrix.itemsByKey(1)?.length ?? -1).toBe(1);
     expect(matrix.itemsByKey(2)?.length ?? -1).toBe(2);
     expect(matrix.itemsByKey(3)?.length ?? -1).toBe(3);
+  });
+});
+
+describe("SeenEvents", () => {
+  test("SeenOnTable (withSeenOn = true) works", () => {
+    const seenEvents = initSeenEvents(true);
+
+    const res1 = seenEvents.report(dummyEvent("1"), "relay1");
+    expect(res1.hasSeen).toBe(false);
+    expect(res1.seenOn).toEqual(["relay1"]);
+
+    const res2 = seenEvents.report(dummyEvent("2"), "relay2");
+    expect(res2.hasSeen).toBe(false);
+    expect(res2.seenOn).toEqual(["relay2"]);
+
+    const res3 = seenEvents.report(dummyEvent("1"), "relay2");
+    expect(res3.hasSeen).toBe(true);
+    expect(res3.seenOn).toEqual(["relay1", "relay2"]);
+
+    expect(seenEvents.getSeenOn("1")).toEqual(["relay1", "relay2"]);
+    expect(seenEvents.getSeenOn("2")).toEqual(["relay2"]);
+    expect(seenEvents.getSeenOn("3")).toEqual([]);
+  });
+
+  test("SeenEventsSet (withSeenOn = false) works", () => {
+    const seenEvents = initSeenEvents(false);
+
+    const res1 = seenEvents.report(dummyEvent("1"), "relay1");
+    expect(res1.hasSeen).toBe(false);
+    expect(res1.seenOn).toBeUndefined();
+
+    const res2 = seenEvents.report(dummyEvent("2"), "relay2");
+    expect(res2.hasSeen).toBe(false);
+
+    const res3 = seenEvents.report(dummyEvent("1"), "relay2");
+    expect(res3.hasSeen).toBe(true);
   });
 });


### PR DESCRIPTION
Events returned by fetchers now have `seenOn` property if the `withSeenOn` option is set to `true`.  The `seenOn` property has an array of URLs of relays on which the event was seen.

If the `withSeenOn` options is set to `false`, the type of `seenOn` property will be `undefined`.

resolves #32.