### PR TITLE
Change the semantics of fetchers which return an async iterable

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ const fetcher = NostrFetcher.init();
 const relayUrls = [/* relay URLs */];
 
 // fetches all text events since 24 hr ago in streaming manner
-const postIter = await fetcher.allEventsIterator(
+const postIter = fetcher.allEventsIterator(
     relayUrls, 
     /* filter (kinds, authors, ids, tags) */
     { kinds: [ eventKind.text ] },
@@ -84,7 +84,7 @@ const lastMetadata: NostrEvent | undefined = await fetcher.fetchLastEvent(
 );
 
 // fetches latest 10 text posts from each author in `authors`
-const postsPerAuthor = await fetcher.fetchLatestEventsPerAuthor(
+const postsPerAuthor = fetcher.fetchLatestEventsPerAuthor(
     /* authors and relay set */
     // you can also pass a `Map` which has mappings from authors (pubkey) to reley sets,
     // to specify a relay set for each author
@@ -105,7 +105,7 @@ for await (const { author, events } of postsPerAuthor) {
 }
 
 // fetches the last metadata event from each author in `authors`
-const metadataPerAuthor = await fetcher.fetchLastEventPerAuthor(
+const metadataPerAuthor = fetcher.fetchLastEventPerAuthor(
     /* authors and relay set */
     // you can also pass a `Map` which has mappings from authors (pubkey) to reley sets,
     // to specify a relay set for each author
@@ -152,7 +152,7 @@ const fetcher = NostrFetcher.withCustomPool(simplePoolAdapter(pool));
 | [`nostr-relaypool`](https://github.com/adamritter/nostr-relaypool-ts) | `RelayPool`      | `@nostr-fetch/adapter-nostr-relaypool` | `relayPoolAdapter`  |
 | [`@nostr-dev-kit/ndk`](https://github.com/nostr-dev-kit/ndk) | `NDK` | `@nostr-fetch/adapter-ndk` | `ndkAdapter` |
 
-### Aborting
+### Cancelling by AbortController
 
 ```ts
 import { eventKind, NostrFecher } from 'nostr-fetch'
@@ -162,7 +162,7 @@ const relayUrls = [/* relay URLs */];
 
 const abortCtrl = new AbortController();
 
-const evIter = await fetcher.allEventsIterator(
+const evIter = fetcher.allEventsIterator(
     relayUrls,
     {/* filter */},
     {/* time range */},
@@ -236,7 +236,9 @@ This opens up interoperability with other relay pool implementations such as [no
 
 #### `NostrFetcher#shutdown`
 
-Closes all the connections to relays and clean up the internal relay pool.
+Cleans up the internal relay pool.
+
+If you use a fetcher instance initialized via `NostrFetcher.init`, calling this method closes conenctions to all the connected relays.
 
 ---
 
@@ -247,12 +249,12 @@ All methods are instance methods of `NostrFetcher`.
 #### `allEventsIterator`
 
 ```ts
-public async allEventsIterator(
+public allEventsIterator(
     relayUrls: string[],
     filter: FetchFilter,
     timeRangeFilter: FetchTimeRangeFilter,
     options: AllEventsIterOptions = {}
-): Promise<AsyncIterable<NostrEvent>>
+): AsyncIterable<NostrEvent>
 ```
 
 Returns an async iterable of all events matching the filter from Nostr relays specified by the array of URLs.
@@ -261,7 +263,7 @@ You can iterate over events using for-await-of loop.
 
 ```ts
 const fetcher = NostrFetcher.init();
-const events = await fetcher.allEventsIterator([/* relays */], {/* filter */}, {/* time range */});
+const events = fetcher.allEventsIterator([/* relays */], {/* filter */}, {/* time range */});
 for await (const ev of events) {
     // process events
 }
@@ -332,12 +334,12 @@ Returns `undefined` if no event matching the filter exists in any relay.
 #### `fetchLatestEventsPerAuthor`
 
 ```ts
-public async fetchLatestEventsPerAuthor(
+public fetchLatestEventsPerAuthor(
     authorsAndRelays: AuthorsAndRelays,
     otherFilter: Omit<FetchFilter, "authors">,
     limit: number,
     options: FetchLatestOptions = {}
-): Promise<AsyncIterable<{ author: string; events: NostrEvent[] }>>
+): AsyncIterable<{ author: string; events: NostrEvent[] }>
 ```
 Fetches latest up to `limit` events **for each author specified by `authorsAndRelays`**.
 
@@ -355,11 +357,11 @@ Each array of events in the result are sorted in "newest to oldest" order.
 #### `fetchLastEventPerAuthor`
 
 ```ts
-public async fetchLastEventPerAuthor(
+public fetchLastEventPerAuthor(
     authorsAndRelays: AuthorsAndRelays,
     otherFilter: Omit<FetchFilter, "authors">,
     options: FetchLatestOptions = {}
-): Promise<AsyncIterable<{ author: string; event: NostrEvent | undefined }>>
+): AsyncIterable<{ author: string; event: NostrEvent | undefined }>
 ```
 
 Fetches the last event **for each author specified by `authorsAndRelays`**.

--- a/packages/examples/src/abort.ts
+++ b/packages/examples/src/abort.ts
@@ -8,7 +8,7 @@ const main = async () => {
   const abortCtrl = new AbortController();
 
   // fetch all text events (kind: 1) posted in the last hour from the relays
-  const evIter = await fetcher.allEventsIterator(
+  const evIter = fetcher.allEventsIterator(
     defaultRelays,
     {
       kinds: [eventKind.text],

--- a/packages/examples/src/allEventsIter.ts
+++ b/packages/examples/src/allEventsIter.ts
@@ -8,7 +8,7 @@ const main = async () => {
   const fetcher = NostrFetcher.init();
 
   // fetch all text events (kind: 1) posted in the last hour from the relays
-  const eventsIter = await fetcher.allEventsIterator(
+  const eventsIter = fetcher.allEventsIterator(
     defaultRelays,
     {
       kinds: [eventKind.text],

--- a/packages/examples/src/backpressure.ts
+++ b/packages/examples/src/backpressure.ts
@@ -9,7 +9,7 @@ const main = async () => {
   const fetcher = NostrFetcher.init();
 
   // fetch all text events (kind: 1) posted in the last 3 hours from the relays
-  const eventsIter = await fetcher.allEventsIterator(
+  const eventsIter = fetcher.allEventsIterator(
     defaultRelays,
     {
       kinds: [eventKind.text],

--- a/packages/examples/src/fetchLastPerAuthor.ts
+++ b/packages/examples/src/fetchLastPerAuthor.ts
@@ -29,7 +29,7 @@ const main = async () => {
     .map((t) => t[1] as string);
 
   // get profile (metadata) events for each followee
-  const profilePerAuthor = await fetcher.fetchLastEventPerAuthor(
+  const profilePerAuthor = fetcher.fetchLastEventPerAuthor(
     { authors: followees, relayUrls: defaultRelays },
     {
       kinds: [eventKind.metadata],

--- a/packages/examples/src/fetchLatestPerAuthor.ts
+++ b/packages/examples/src/fetchLatestPerAuthor.ts
@@ -26,7 +26,7 @@ const main = async () => {
     .map((t) => t[1] as string);
 
   // get latest 10 posts for each followee
-  const latestPostsPerFollowee = await fetcher.fetchLatestEventsPerAuthor(
+  const latestPostsPerFollowee = fetcher.fetchLatestEventsPerAuthor(
     { authors: followees, relayUrls: defaultRelays },
     { kinds: [eventKind.text] },
     10

--- a/packages/examples/src/interop/ndk.ts
+++ b/packages/examples/src/interop/ndk.ts
@@ -18,7 +18,7 @@ const main = async () => {
   const fetcher = NostrFetcher.withCustomPool(ndkAdapter(ndk));
 
   // fetch all text events (kind: 1) posted in the last hour from the relays
-  const eventsIter = await fetcher.allEventsIterator(
+  const eventsIter = fetcher.allEventsIterator(
     defaultRelays,
     {
       kinds: [eventKind.text],

--- a/packages/examples/src/interop/relayPoolTs.ts
+++ b/packages/examples/src/interop/relayPoolTs.ts
@@ -10,7 +10,7 @@ const main = async () => {
   const fetcher = NostrFetcher.withCustomPool(relayPoolAdapter(pool));
 
   // fetch all text events (kind: 1) posted in the last hour from the relays
-  const eventsIter = await fetcher.allEventsIterator(
+  const eventsIter = fetcher.allEventsIterator(
     defaultRelays,
     {
       kinds: [eventKind.text],

--- a/packages/examples/src/interop/simplePool.ts
+++ b/packages/examples/src/interop/simplePool.ts
@@ -11,7 +11,7 @@ const main = async () => {
   const fetcher = NostrFetcher.withCustomPool(simplePoolAdapter(pool));
 
   // fetch all text events (kind: 1) posted in the last hour from the relays
-  const eventsIter = await fetcher.allEventsIterator(
+  const eventsIter = fetcher.allEventsIterator(
     defaultRelays,
     {
       kinds: [eventKind.text],

--- a/packages/examples/src/outboxModel.ts
+++ b/packages/examples/src/outboxModel.ts
@@ -26,7 +26,7 @@ const fetchFollowees = async (pubkey: string): Promise<string[]> => {
 
 // get write relays for each pubkeys
 const fetchWriteRelaysPerAuthors = async (authors: string[]): Promise<Map<string, string[]>> => {
-  const iter = await fetcher.fetchLastEventPerAuthor(
+  const iter = fetcher.fetchLastEventPerAuthor(
     { authors, relayUrls: defaultRelays },
     {
       kinds: [eventKind.contacts, eventKind.relayList],
@@ -58,7 +58,7 @@ const main = async () => {
   }
 
   // get the last post for each followee
-  const lastPostsPerFollowee = await fetcher.fetchLastEventPerAuthor(writeRelaysPerFollowees, {
+  const lastPostsPerFollowee = fetcher.fetchLastEventPerAuthor(writeRelaysPerFollowees, {
     kinds: [eventKind.text],
   });
   for await (const { author, event: ev } of lastPostsPerFollowee) {

--- a/packages/examples/src/search.ts
+++ b/packages/examples/src/search.ts
@@ -15,7 +15,7 @@ const main = async () => {
   const fetcher = NostrFetcher.init();
 
   // fetch all the text events (kind: 1) which match the search query and have posted in the last 24 hours
-  const eventsIter = await fetcher.allEventsIterator(
+  const eventsIter = fetcher.allEventsIterator(
     searchRelays,
     {
       kinds: [eventKind.text],

--- a/packages/nostr-fetch/src/fetcher.spec.ts
+++ b/packages/nostr-fetch/src/fetcher.spec.ts
@@ -171,13 +171,13 @@ describe.concurrent("NostrFetcher", () => {
 
   describe.concurrent("allEventsIterator", () => {
     test("fetches all events (single relay)", async () => {
-      const evIter = await fetcher.allEventsIterator(["wss://relay1"], {}, {}, { limitPerReq: 5 });
+      const evIter = fetcher.allEventsIterator(["wss://relay1"], {}, {}, { limitPerReq: 5 });
       const evs = await collectAsyncIter(evIter);
       expect(evs.length).toBe(30);
     });
 
     test("fetches all events (multiple relays)", async () => {
-      const evIter = await fetcher.allEventsIterator(
+      const evIter = fetcher.allEventsIterator(
         ["wss://relay1", "wss://relay2", "wss://relay3"],
         {},
         {},
@@ -188,18 +188,14 @@ describe.concurrent("NostrFetcher", () => {
     });
 
     test("fetches all events within time range (single relay)", async () => {
-      const evIter = await fetcher.allEventsIterator(
-        ["wss://relay1"],
-        {},
-        { since: 1000, until: 2000 }
-      );
+      const evIter = fetcher.allEventsIterator(["wss://relay1"], {}, { since: 1000, until: 2000 });
       const evs = await collectAsyncIter(evIter);
       expect(evs.length).toBe(10);
       assert(evs.every(({ content }) => content.includes("within range")));
     });
 
     test("fetches all events within time range (multiple relays)", async () => {
-      const evIter = await fetcher.allEventsIterator(
+      const evIter = fetcher.allEventsIterator(
         ["wss://relay1", "wss://relay2", "wss://relay3"],
         {},
         { since: 1000, until: 2000 }
@@ -209,20 +205,20 @@ describe.concurrent("NostrFetcher", () => {
       assert(evs.every(({ content }) => content.includes("within range")));
     });
 
-    test("throws error if time range is invalid", async () => {
-      await expect(
-        fetcher.allEventsIterator(["wss://healthy"], {}, { since: 1, until: 0 })
-      ).rejects.toThrow("Invalid time range (since > until)");
+    test("throws error if time range is invalid", () => {
+      expect(() => {
+        fetcher.allEventsIterator(["wss://healthy"], {}, { since: 1, until: 0 });
+      }).toThrow("Invalid time range (since > until)");
     });
 
     test("dedups events based on event id", async () => {
-      const evIter = await fetcher.allEventsIterator(["wss://dup1", "wss://dup2"], {}, {});
+      const evIter = fetcher.allEventsIterator(["wss://dup1", "wss://dup2"], {}, {});
       const evs = await collectAsyncIter(evIter);
       expect(evs.length).toBe(1);
     });
 
     test("sends the same event multiple times with updated seenOn", async () => {
-      const evIter = await fetcher.allEventsIterator(
+      const evIter = fetcher.allEventsIterator(
         ["wss://dup1", "wss://dup2"],
         {},
         {},
@@ -237,18 +233,14 @@ describe.concurrent("NostrFetcher", () => {
     });
 
     test("verifies signature by default", async () => {
-      const evIter = await fetcher.allEventsIterator(
-        ["wss://healthy", "wss://invalid-sig"],
-        {},
-        {}
-      );
+      const evIter = fetcher.allEventsIterator(["wss://healthy", "wss://invalid-sig"], {}, {});
       const evs = await collectAsyncIter(evIter);
       expect(evs.length).toBe(10);
       assert(evs.every(({ content }) => content.includes("healthy")));
     });
 
     test("skips signature verification if skipVerification is true", async () => {
-      const evIter = await fetcher.allEventsIterator(
+      const evIter = fetcher.allEventsIterator(
         ["wss://healthy", "wss://invalid-sig"],
         {},
         {},
@@ -262,18 +254,14 @@ describe.concurrent("NostrFetcher", () => {
     });
 
     test("ignores unreachable relays", async () => {
-      const evIter = await fetcher.allEventsIterator(
-        ["wss://healthy", "wss://unreachable"],
-        {},
-        {}
-      );
+      const evIter = fetcher.allEventsIterator(["wss://healthy", "wss://unreachable"], {}, {});
       const evs = await collectAsyncIter(evIter);
       expect(evs.length).toBe(10);
       assert(evs.every(({ content }) => content.includes("healthy")));
     });
 
     test("skips slow-to-connect relays if timeout exceeds", async () => {
-      const evIter = await fetcher.allEventsIterator(
+      const evIter = fetcher.allEventsIterator(
         ["wss://healthy", "wss://slow-to-connect"],
         {},
         {},
@@ -285,7 +273,7 @@ describe.concurrent("NostrFetcher", () => {
     });
 
     test("waits slow-to-connect relays until timeout", async () => {
-      const evIter = await fetcher.allEventsIterator(
+      const evIter = fetcher.allEventsIterator(
         ["wss://healthy", "wss://slow-to-connect"],
         {},
         {},
@@ -301,7 +289,7 @@ describe.concurrent("NostrFetcher", () => {
     });
 
     test("cut off slow-to-return-events relays if timeout exceeds", async () => {
-      const evIter = await fetcher.allEventsIterator(
+      const evIter = fetcher.allEventsIterator(
         ["wss://healthy", "wss://slow-to-return-events"],
         {},
         {},
@@ -313,7 +301,7 @@ describe.concurrent("NostrFetcher", () => {
     });
 
     test("waits slow-to-return-events relays until timeout", async () => {
-      const evIter = await fetcher.allEventsIterator(
+      const evIter = fetcher.allEventsIterator(
         ["wss://healthy", "wss://slow-to-return-events"],
         {},
         {},
@@ -334,7 +322,7 @@ describe.concurrent("NostrFetcher", () => {
         ac.abort();
       }, 500);
 
-      const evIter = await fetcher.allEventsIterator(
+      const evIter = fetcher.allEventsIterator(
         ["wss://delayed"],
         {},
         {},
@@ -345,7 +333,7 @@ describe.concurrent("NostrFetcher", () => {
     });
 
     test("uses only searchable relays (supports NIP-50) if the filter contains search field", async () => {
-      const evIter = await fetcher.allEventsIterator(
+      const evIter = fetcher.allEventsIterator(
         ["wss://healthy", "wss://search"],
         { search: "search" },
         {}
@@ -358,7 +346,7 @@ describe.concurrent("NostrFetcher", () => {
 
   describe.concurrent("fetchAllEvents", () => {
     test("throws error if time range is invalid", async () => {
-      await expect(
+      await expect(() =>
         fetcher.fetchAllEvents(["wss://healthy"], {}, { since: 1, until: 0 })
       ).rejects.toThrow("Invalid time range (since > until)");
     });
@@ -388,7 +376,7 @@ describe.concurrent("NostrFetcher", () => {
 
   describe.concurrent("fetchLatestEvents", () => {
     test("throws error if limit <= 0", async () => {
-      await expect(fetcher.fetchLatestEvents(["wss://healthy"], {}, 0)).rejects.toThrow(
+      await expect(() => fetcher.fetchLatestEvents(["wss://healthy"], {}, 0)).rejects.toThrow(
         '"limit" should be positive number'
       );
     });
@@ -452,7 +440,7 @@ describe.concurrent("NostrFetcher", () => {
     const pkC = pubkeyFromAuthorName("cat");
 
     test("relay set for all authors", async () => {
-      const iter = await fetcher.fetchLatestEventsPerAuthor(
+      const iter = fetcher.fetchLatestEventsPerAuthor(
         {
           authors: [pkA, pkB, pkC],
           relayUrls: ["wss://per-author1", "wss://per-author2", "wss://per-author3"],
@@ -485,7 +473,7 @@ describe.concurrent("NostrFetcher", () => {
 
       const eventsPerAuthor = new Map<string, NostrEvent[]>();
 
-      const iter = await fetcher.fetchLatestEventsPerAuthor(relaySetPerAuthor, {}, 5);
+      const iter = fetcher.fetchLatestEventsPerAuthor(relaySetPerAuthor, {}, 5);
       for await (const { author, events } of iter) {
         eventsPerAuthor.set(author, events);
 
@@ -517,7 +505,7 @@ describe.concurrent("NostrFetcher", () => {
     });
 
     test("withSeenOn: true works correctly", async () => {
-      const iter = await fetcher.fetchLatestEventsPerAuthor(
+      const iter = fetcher.fetchLatestEventsPerAuthor(
         { authors: [pubkeyFromAuthorName("test")], relayUrls: ["wss://dup1", "wss://dup2"] },
         {},
         1,
@@ -539,7 +527,7 @@ describe.concurrent("NostrFetcher", () => {
     const pkC = pubkeyFromAuthorName("cat");
 
     test("single relay set for all authors", async () => {
-      const iter = await fetcher.fetchLastEventPerAuthor(
+      const iter = fetcher.fetchLastEventPerAuthor(
         {
           authors: [pkA, pkB, pkC],
           relayUrls: ["wss://per-author1", "wss://per-author2", "wss://per-author3"],
@@ -565,7 +553,7 @@ describe.concurrent("NostrFetcher", () => {
         [pkB, ["wss://per-author2", "wss://per-author3"]],
         [pkC, ["wss://per-author3", "wss://per-author1"]],
       ]);
-      const iter = await fetcher.fetchLastEventPerAuthor(relaySetPerAuthor, {});
+      const iter = fetcher.fetchLastEventPerAuthor(relaySetPerAuthor, {});
 
       const authors: string[] = [];
 


### PR DESCRIPTION
List of fetchers affected:
- `allEventsIterator`
- `fetchLatestEventsPerAuthor`
- `fetchLastEventPerAuthor`

So far, they initialize an async iterable *asynchronously*.  Especially, attempts to ensure connections to relays are performed when fetcher method is called.  That fact is reflected in the return types of the fetchers (`Promise<AsyncIterable<...>>`).

This PR changes that semantics.  From now on, they initialize an async iterable *synchronously*.  In this setting, attempts to ensure connections to relays are performed when *`next` method of returned iterable is called for the first time*.  Return types of them no longer have `Promise` part (`AsyncIterable<...>`).  Note that assertions for arguments are still performed on calling the fetchers.

resolves #47.