### PR TITLE
Add fetch statistics

### DIFF
--- a/packages/examples/src/statsListener.ts
+++ b/packages/examples/src/statsListener.ts
@@ -1,0 +1,37 @@
+import { NostrFetcher, eventKind } from "nostr-fetch";
+import "websocket-polyfill";
+
+import { defaultRelays, nHoursAgo } from "./utils";
+
+const main = async () => {
+  // initialize fetcher based on nostr-relaypool's `RelayPool`
+  const fetcher = NostrFetcher.init({ minLogLevel: "info" });
+
+  // fetch all text events (kind: 1) posted in the last hour from the relays
+  const eventsIter = fetcher.allEventsIterator(
+    defaultRelays,
+    {
+      kinds: [eventKind.text],
+    },
+    {
+      since: nHoursAgo(1),
+    },
+    {
+      statsListener: (stats) => console.error(stats),
+      statsNotifIntervalMs: 500,
+    }
+  );
+
+  for await (const ev of eventsIter) {
+    console.log(ev.content);
+  }
+
+  fetcher.shutdown();
+};
+
+main()
+  .then(() => console.log("fin"))
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });

--- a/packages/nostr-fetch-kernel/src/channel.ts
+++ b/packages/nostr-fetch-kernel/src/channel.ts
@@ -23,6 +23,7 @@ interface ChannelSender<T> {
   close(): void;
 
   waitUntilDrained(): Promise<void>;
+  numBufferedItems(): number;
 }
 
 interface ChannelIter<T> {
@@ -114,6 +115,10 @@ export class Channel<T> {
     // sendQ have overflowed -> wait until drained
     this.#drainWaiter = new Deferred();
     return this.#drainWaiter.promise;
+  }
+
+  numBufferedItems(): number {
+    return this.#sendQ.length;
   }
 
   private get isCompleted(): boolean {

--- a/packages/nostr-fetch/src/fetcher.ts
+++ b/packages/nostr-fetch/src/fetcher.ts
@@ -332,6 +332,7 @@ export class NostrFetcher {
                 }
 
                 statsMngr?.eventFetched();
+                statsMngr?.setNumBufferedEvents(tx.numBufferedItems());
               }
             }
             statsMngr?.subClosed();
@@ -549,6 +550,7 @@ export class NostrFetcher {
                 }
 
                 statsMngr?.eventFetched();
+                statsMngr?.setNumBufferedEvents(tx.numBufferedItems());
               }
             }
             statsMngr?.subClosed();
@@ -862,6 +864,7 @@ export class NostrFetcher {
                 }
 
                 statsMngr?.eventFetched();
+                statsMngr?.setNumBufferedEvents(tx.numBufferedItems());
               }
             }
             statsMngr?.subClosed();

--- a/packages/nostr-fetch/src/fetcherHelper.ts
+++ b/packages/nostr-fetch/src/fetcherHelper.ts
@@ -296,6 +296,7 @@ export class FetchStatsManager {
     },
     count: {
       fetchedEvents: 0,
+      bufferedEvents: 0,
       openedSubs: 0,
       runningSubs: 0,
     },
@@ -333,6 +334,10 @@ export class FetchStatsManager {
   /* counts */
   eventFetched(): void {
     this.#stats.count.fetchedEvents++;
+  }
+
+  setNumBufferedEvents(n: number): void {
+    this.#stats.count.bufferedEvents = n;
   }
 
   subOpened(): void {

--- a/packages/nostr-fetch/src/index.ts
+++ b/packages/nostr-fetch/src/index.ts
@@ -1,4 +1,6 @@
-export { NostrEvent, eventKind } from "@nostr-fetch/kernel/nostr";
-export { normalizeRelayUrl, normalizeRelayUrls } from "@nostr-fetch/kernel/utils";
 export * from "./fetcher";
 export { NostrFetchError } from "./fetcherHelper";
+export { FetchStats, FetchStatsListener } from "./types";
+
+export { NostrEvent, eventKind } from "@nostr-fetch/kernel/nostr";
+export { normalizeRelayUrl, normalizeRelayUrls } from "@nostr-fetch/kernel/utils";

--- a/packages/nostr-fetch/src/types.ts
+++ b/packages/nostr-fetch/src/types.ts
@@ -1,0 +1,13 @@
+export type FetchStats = {
+  progress: {
+    max: number;
+    current: number;
+  };
+  count: {
+    fetchedEvents: number;
+    openedSubs: number;
+    runningSubs: number;
+  };
+};
+
+export type FetchStatsListener = (stats: FetchStats) => void;

--- a/packages/nostr-fetch/src/types.ts
+++ b/packages/nostr-fetch/src/types.ts
@@ -5,6 +5,7 @@ export type FetchStats = {
   };
   count: {
     fetchedEvents: number;
+    bufferedEvents: number;
     openedSubs: number;
     runningSubs: number;
   };


### PR DESCRIPTION
Added means to get fetch statistics.

Users of the fetcher now can pass a listener for stats information as the `statsListener` fetch option.  Additionally, users can control the interval of stats notification by the `statsNotifIntervalMs` fetch option.
