### PR TITLE
Fixups before 0.12.0

### DIFF
--- a/packages/adapter-ndk/README.md
+++ b/packages/adapter-ndk/README.md
@@ -8,11 +8,11 @@ If you want to use nostr-fetch, [here](https://github.com/jiftechnify/nostr-fetc
 
 ```ts
 import NDK from '@nostr-dev-kit/ndk';
-import { NostrFetcher, normalizeRelayUrls } from 'nostr-fetch';
+import { NostrFetcher, normalizeRelayUrlSet } from 'nostr-fetch';
 import { ndkAdapter } from '@nostr-fetch/adapter-ndk';
 
-// You should normalize relay URLs by `normalizeRelayUrls` before passing them to NDK's constructor if working with nostr-fetch!
-const explicitRelays = normalizeRelayUrls([
+// You should normalize a set of relay URLs by `normalizeRelayUrlSet` before passing them to NDK's constructor if working with nostr-fetch!
+const explicitRelays = normalizeRelayUrlSet([
     "wss://relay-jp.nostr.wirednet.jp",
     "wss://relay.damus.io",
 ]);

--- a/packages/adapter-ndk/src/adapter.ts
+++ b/packages/adapter-ndk/src/adapter.ts
@@ -1,7 +1,7 @@
+import { setupSubscriptionAbortion } from "@nostr-fetch/kernel/adapterHelpers";
 import { Channel } from "@nostr-fetch/kernel/channel";
 import { DebugLogger } from "@nostr-fetch/kernel/debugLogger";
 import {
-  FetchTillEoseAbortedSignal,
   FetchTillEoseFailedSignal,
   type EnsureRelaysOptions,
   type FetchTillEoseOptions,
@@ -155,6 +155,9 @@ export class NDKAdapter implements NostrFetcherBackend {
     };
     relay.on("notice", onNotice);
 
+    // setup abortion
+    const resetAutoAbortTimer = setupSubscriptionAbortion(closeSub, tx, options);
+
     // handle subscription events
     sub.on("event", (ndkEv: NDKEvent) => {
       tx.send(ndkEv.rawEvent() as NostrEvent);
@@ -165,29 +168,6 @@ export class NDKAdapter implements NostrFetcherBackend {
       tx.close();
     });
 
-    // auto abortion
-    let subAutoAbortTimer: NodeJS.Timer | undefined;
-    const resetAutoAbortTimer = () => {
-      if (subAutoAbortTimer !== undefined) {
-        clearTimeout(subAutoAbortTimer);
-        subAutoAbortTimer = undefined;
-      }
-      subAutoAbortTimer = setTimeout(() => {
-        closeSub();
-        tx.error(new FetchTillEoseAbortedSignal("subscription aborted before EOSE due to timeout"));
-      }, options.abortSubBeforeEoseTimeoutMs);
-    };
-    resetAutoAbortTimer(); // initiate subscription auto abortion timer
-
-    // handle abortion by AbortController
-    if (options.abortSignal?.aborted) {
-      closeSub();
-      tx.error(new FetchTillEoseAbortedSignal("subscription aborted by AbortController"));
-    }
-    options.abortSignal?.addEventListener("abort", () => {
-      closeSub();
-      tx.error(new FetchTillEoseAbortedSignal("subscription aborted by AbortController"));
-    });
     return chIter;
   }
 

--- a/packages/adapter-ndk/src/adapter.ts
+++ b/packages/adapter-ndk/src/adapter.ts
@@ -9,7 +9,7 @@ import {
   type NostrFetcherCommonOptions,
 } from "@nostr-fetch/kernel/fetcherBackend";
 import type { Filter, NostrEvent } from "@nostr-fetch/kernel/nostr";
-import { normalizeRelayUrl, normalizeRelayUrls, withTimeout } from "@nostr-fetch/kernel/utils";
+import { normalizeRelayUrl, normalizeRelayUrlSet, withTimeout } from "@nostr-fetch/kernel/utils";
 
 import type NDK from "@nostr-dev-kit/ndk";
 import { NDKEvent, NDKRelay, NDKRelaySet, NDKRelayStatus } from "@nostr-dev-kit/ndk";
@@ -38,7 +38,7 @@ export class NDKAdapter implements NostrFetcherBackend {
     relayUrls: string[],
     { connectTimeoutMs }: EnsureRelaysOptions,
   ): Promise<string[]> {
-    const normalizedUrls = normalizeRelayUrls(relayUrls);
+    const normalizedUrls = normalizeRelayUrlSet(relayUrls);
 
     // partition relays to 2 groups:
     // 1. managed by the NDK pool or the adapter

--- a/packages/adapter-ndk/src/index.ts
+++ b/packages/adapter-ndk/src/index.ts
@@ -15,11 +15,11 @@ import type {
  * @example
  * ```
  * import NDK from '@nostr-dev-kit/ndk';
- * import { NostrFetcher, normalizeRelayUrls } from 'nostr-fetch';
+ * import { NostrFetcher, normalizeRelayUrlSet } from 'nostr-fetch';
  * import { ndkAdapter } from '@nostr-fetch/adapter-ndk';
  *
- * // You should normalize relay URLs by `normalizeRelayUrls` before passing them to NDK's constructor if working with nostr-fetch!
- * const explicitRelays = normalizeRelayUrls([
+ * // You should normalize a set of relay URLs by `normalizeRelayUrlSet` before passing them to NDK's constructor if working with nostr-fetch!
+ * const explicitRelays = normalizeRelayUrlSet([
  *   "wss://relay-jp.nostr.wirednet.jp",
  *   "wss://relay.damus.io",
  * ]);

--- a/packages/adapter-nostr-relaypool/src/adapter.ts
+++ b/packages/adapter-nostr-relaypool/src/adapter.ts
@@ -9,7 +9,7 @@ import {
   type NostrFetcherCommonOptions,
 } from "@nostr-fetch/kernel/fetcherBackend";
 import type { Filter, NostrEvent } from "@nostr-fetch/kernel/nostr";
-import { normalizeRelayUrls, withTimeout } from "@nostr-fetch/kernel/utils";
+import { normalizeRelayUrlSet, withTimeout } from "@nostr-fetch/kernel/utils";
 
 import type { RelayPool } from "nostr-relaypool";
 
@@ -91,7 +91,7 @@ export class NRTPoolAdapter implements NostrFetcherBackend {
     relayUrls: string[],
     { connectTimeoutMs }: EnsureRelaysOptions,
   ): Promise<string[]> {
-    const normalizedUrls = normalizeRelayUrls(relayUrls);
+    const normalizedUrls = normalizeRelayUrlSet(relayUrls);
 
     const ensure = (rurl: string) =>
       new Promise<string>((resolve, reject) => {

--- a/packages/adapter-nostr-relaypool/src/adapter.ts
+++ b/packages/adapter-nostr-relaypool/src/adapter.ts
@@ -1,7 +1,7 @@
+import { setupSubscriptionAbortion } from "@nostr-fetch/kernel/adapterHelpers";
 import { Channel } from "@nostr-fetch/kernel/channel";
 import { DebugLogger } from "@nostr-fetch/kernel/debugLogger";
 import {
-  FetchTillEoseAbortedSignal,
   FetchTillEoseFailedSignal,
   type EnsureRelaysOptions,
   type FetchTillEoseOptions,
@@ -177,6 +177,32 @@ export class NRTPoolAdapter implements NostrFetcherBackend {
     // it's the very behavior we want here!
     const filterWithRelay = { ...filter, relay: relayUrl };
 
+    // common process for subscription abortion
+    const closeSub = () => {
+      unsub();
+      removeRelayListeners();
+    };
+
+    // error handlings
+    const onNotice = (msg: string) => {
+      closeSub();
+      tx.error(new FetchTillEoseFailedSignal(`NOTICE: ${JSON.stringify(msg)}`));
+    };
+    const onError = (msg: string) => {
+      removeRelayListeners();
+      tx.error(new FetchTillEoseFailedSignal(`ERROR: ${msg}`));
+    };
+    const removeRelayListeners = () => {
+      this.removeListener(relayUrl, "notice");
+      this.removeListener(relayUrl, "error");
+    };
+
+    this.addListener(relayUrl, "notice", onNotice);
+    this.addListener(relayUrl, "error", onError);
+
+    // setup abortion
+    const resetAutoAbortTimer = setupSubscriptionAbortion(closeSub, tx, options);
+
     // start subscription
     const unsub = this.#pool.subscribe(
       [filterWithRelay],
@@ -198,52 +224,6 @@ export class NRTPoolAdapter implements NostrFetcherBackend {
         unsubscribeOnEose: true,
       },
     );
-
-    // error handlings
-    const onNotice = (msg: string) => {
-      unsub();
-      removeRelayListeners();
-      tx.error(new FetchTillEoseFailedSignal(`NOTICE: ${JSON.stringify(msg)}`));
-    };
-    const onError = (msg: string) => {
-      removeRelayListeners();
-      tx.error(new FetchTillEoseFailedSignal(`ERROR: ${msg}`));
-    };
-    const removeRelayListeners = () => {
-      this.removeListener(relayUrl, "notice");
-      this.removeListener(relayUrl, "error");
-    };
-
-    this.addListener(relayUrl, "notice", onNotice);
-    this.addListener(relayUrl, "error", onError);
-
-    // common process for subscription abortion
-    const abortSub = (msg: string) => {
-      unsub();
-      removeRelayListeners();
-      tx.error(new FetchTillEoseAbortedSignal(msg));
-    };
-
-    // auto abortion
-    let subAutoAbortTimer: NodeJS.Timer | undefined;
-    const resetAutoAbortTimer = () => {
-      if (subAutoAbortTimer !== undefined) {
-        clearTimeout(subAutoAbortTimer);
-        subAutoAbortTimer = undefined;
-      }
-      subAutoAbortTimer = setTimeout(() => {
-        abortSub("subscription aborted before EOSE due to timeout");
-      }, options.abortSubBeforeEoseTimeoutMs);
-    };
-    resetAutoAbortTimer(); // initiate subscription auto abortion timer
-
-    // handle abortion by AbortController
-    if (options.abortSignal?.aborted) {
-      abortSub("subscription aborted by AbortController");
-    }
-    options.abortSignal?.addEventListener("abort", () => {
-      abortSub("subscription aborted by AbortController");
-    });
 
     return chIter;
   }

--- a/packages/adapter-nostr-tools/src/adapter.ts
+++ b/packages/adapter-nostr-tools/src/adapter.ts
@@ -1,7 +1,7 @@
+import { setupSubscriptionAbortion } from "@nostr-fetch/kernel/adapterHelpers";
 import { Channel } from "@nostr-fetch/kernel/channel";
 import { DebugLogger } from "@nostr-fetch/kernel/debugLogger";
 import {
-  FetchTillEoseAbortedSignal,
   FetchTillEoseFailedSignal,
   type EnsureRelaysOptions,
   type FetchTillEoseOptions,
@@ -138,6 +138,9 @@ export class SimplePoolExt implements NostrFetcherBackend {
     relay.on("notice", onNotice);
     relay.on("error", onError);
 
+    // setup abortion
+    const resetAutoAbortTimer = setupSubscriptionAbortion(closeSub, tx, options);
+
     // handle subscription events
     sub.on("event", (ev: NostrEvent) => {
       tx.send(ev);
@@ -146,30 +149,6 @@ export class SimplePoolExt implements NostrFetcherBackend {
     sub.on("eose", () => {
       closeSub();
       tx.close();
-    });
-
-    // auto abortion
-    let subAutoAbortTimer: NodeJS.Timer | undefined;
-    const resetAutoAbortTimer = () => {
-      if (subAutoAbortTimer !== undefined) {
-        clearTimeout(subAutoAbortTimer);
-        subAutoAbortTimer = undefined;
-      }
-      subAutoAbortTimer = setTimeout(() => {
-        closeSub();
-        tx.error(new FetchTillEoseAbortedSignal("subscription aborted before EOSE due to timeout"));
-      }, options.abortSubBeforeEoseTimeoutMs);
-    };
-    resetAutoAbortTimer(); // initiate subscription auto abortion timer
-
-    // handle abortion by AbortController
-    if (options.abortSignal?.aborted) {
-      closeSub();
-      tx.error(new FetchTillEoseAbortedSignal("subscription aborted by AbortController"));
-    }
-    options.abortSignal?.addEventListener("abort", () => {
-      closeSub();
-      tx.error(new FetchTillEoseAbortedSignal("subscription aborted by AbortController"));
     });
 
     return chIter;

--- a/packages/adapter-nostr-tools/src/adapter.ts
+++ b/packages/adapter-nostr-tools/src/adapter.ts
@@ -9,7 +9,7 @@ import {
   type NostrFetcherCommonOptions,
 } from "@nostr-fetch/kernel/fetcherBackend";
 import { NostrEvent, type Filter } from "@nostr-fetch/kernel/nostr";
-import { normalizeRelayUrl, normalizeRelayUrls, withTimeout } from "@nostr-fetch/kernel/utils";
+import { normalizeRelayUrl, normalizeRelayUrlSet, withTimeout } from "@nostr-fetch/kernel/utils";
 
 import type { SimplePool, Relay as ToolsRelay } from "nostr-tools";
 
@@ -40,7 +40,7 @@ export class SimplePoolExt implements NostrFetcherBackend {
     relayUrls: string[],
     { connectTimeoutMs }: EnsureRelaysOptions,
   ): Promise<string[]> {
-    const normalizedUrls = normalizeRelayUrls(relayUrls);
+    const normalizedUrls = normalizeRelayUrlSet(relayUrls);
 
     const ensure = async (rurl: string) => {
       const logger = this.#debugLogger?.subLogger(rurl);

--- a/packages/examples/src/abort.ts
+++ b/packages/examples/src/abort.ts
@@ -16,7 +16,7 @@ const main = async () => {
     {
       since: nHoursAgo(1),
     },
-    { abortSignal: abortCtrl.signal } // pass `AbortController.signal` to enable abortion
+    { abortSignal: abortCtrl.signal }, // pass `AbortController.signal` to enable abortion
   );
 
   // abort fetching after 1 sec.

--- a/packages/examples/src/allEventsIter.ts
+++ b/packages/examples/src/allEventsIter.ts
@@ -18,7 +18,7 @@ const main = async () => {
     },
     {
       skipVerification: true,
-    }
+    },
   );
 
   for await (const ev of eventsIter) {

--- a/packages/examples/src/backpressure.ts
+++ b/packages/examples/src/backpressure.ts
@@ -20,7 +20,7 @@ const main = async () => {
     {
       skipVerification: true,
       enableBackpressure: true, // enabling backpressure mode!
-    }
+    },
   );
 
   for await (const ev of eventsIter) {

--- a/packages/examples/src/fetchAll.ts
+++ b/packages/examples/src/fetchAll.ts
@@ -15,7 +15,7 @@ const main = async () => {
     {
       since: nHoursAgo(1),
     },
-    { sort: true }
+    { sort: true },
   );
 
   console.log(`fetched ${events.length} events`);

--- a/packages/examples/src/fetchLast.ts
+++ b/packages/examples/src/fetchLast.ts
@@ -12,8 +12,8 @@ const main = async () => {
       fetcher.fetchLastEvent(defaultRelays, {
         kinds: [kind],
         authors: ["d1d1747115d16751a97c239f46ec1703292c3b7e9988b9ebdd4ec4705b15ed44"],
-      })
-    )
+      }),
+    ),
   );
 
   console.log("last metadata:", lastMetadata);

--- a/packages/examples/src/fetchLastPerAuthor.ts
+++ b/packages/examples/src/fetchLastPerAuthor.ts
@@ -33,7 +33,7 @@ const main = async () => {
     { authors: followees, relayUrls: defaultRelays },
     {
       kinds: [eventKind.metadata],
-    }
+    },
   );
 
   // display the name in profile for each author

--- a/packages/examples/src/fetchLatest.ts
+++ b/packages/examples/src/fetchLatest.ts
@@ -12,7 +12,7 @@ const main = async () => {
     {
       kinds: [eventKind.text],
     },
-    100
+    100,
     // { skipVerification: true }
   );
 

--- a/packages/examples/src/fetchLatestPerAuthor.ts
+++ b/packages/examples/src/fetchLatestPerAuthor.ts
@@ -29,7 +29,7 @@ const main = async () => {
   const latestPostsPerFollowee = fetcher.fetchLatestEventsPerAuthor(
     { authors: followees, relayUrls: defaultRelays },
     { kinds: [eventKind.text] },
-    10
+    10,
   );
 
   for await (const { author, events } of latestPostsPerFollowee) {

--- a/packages/examples/src/interop/ndk.ts
+++ b/packages/examples/src/interop/ndk.ts
@@ -1,12 +1,12 @@
 import NDK from "@nostr-dev-kit/ndk";
 import { ndkAdapter } from "@nostr-fetch/adapter-ndk";
-import { NostrFetcher, eventKind, normalizeRelayUrls } from "nostr-fetch";
+import { NostrFetcher, eventKind, normalizeRelayUrlSet } from "nostr-fetch";
 import { defaultRelays, nHoursAgo } from "../utils";
 
 import "websocket-polyfill";
 
-// You should normalize relay URLs by `normalizeRelayUrls` before passing them to NDK's constructor if working with nostr-fetch!
-const explicitRelays = normalizeRelayUrls([
+// You should normalize relay URLs by `normalizeRelayUrlSet` before passing them to NDK's constructor if working with nostr-fetch!
+const explicitRelays = normalizeRelayUrlSet([
   "wss://relay-jp.nostr.wirednet.jp",
   "wss://relay.damus.io",
 ]);

--- a/packages/examples/src/outboxModel.ts
+++ b/packages/examples/src/outboxModel.ts
@@ -30,7 +30,7 @@ const fetchWriteRelaysPerAuthors = async (authors: string[]): Promise<Map<string
     { authors, relayUrls: defaultRelays },
     {
       kinds: [eventKind.contacts, eventKind.relayList],
-    }
+    },
   );
   const res = new Map<string, string[]>();
   for await (const { author, event: ev } of iter) {
@@ -58,7 +58,7 @@ const main = async () => {
     {
       kinds: [eventKind.text],
     },
-    { statsListener: (stats) => console.error(stats) }
+    { statsListener: (stats) => console.error(stats) },
   );
   for await (const { author, event: ev } of lastPostsPerFollowee) {
     if (ev !== undefined) {
@@ -71,7 +71,7 @@ const main = async () => {
 
 const printPost = (ev: NostrEvent) => {
   console.log(
-    `last post from author: [${ev.pubkey}] (${new Date(ev.created_at * 1000).toLocaleString()})`
+    `last post from author: [${ev.pubkey}] (${new Date(ev.created_at * 1000).toLocaleString()})`,
   );
   console.log(ev.content);
   console.log();

--- a/packages/examples/src/search.ts
+++ b/packages/examples/src/search.ts
@@ -26,7 +26,7 @@ const main = async () => {
     },
     {
       skipVerification: true,
-    }
+    },
   );
 
   for await (const ev of eventsIter) {

--- a/packages/examples/src/seenOn.ts
+++ b/packages/examples/src/seenOn.ts
@@ -13,7 +13,7 @@ const main = async () => {
       kinds: [eventKind.text],
     },
     100,
-    { withSeenOn: false }
+    { withSeenOn: false },
   );
 
   console.log(`got ${latestPosts.length} events`);

--- a/packages/examples/src/statsListener.ts
+++ b/packages/examples/src/statsListener.ts
@@ -19,7 +19,7 @@ const main = async () => {
     {
       statsListener: (stats) => console.error(stats),
       statsNotifIntervalMs: 500,
-    }
+    },
   );
 
   for await (const ev of eventsIter) {

--- a/packages/examples/src/utils.ts
+++ b/packages/examples/src/utils.ts
@@ -21,7 +21,7 @@ export const getWriteRelaysFromEvent = (ev: NostrEvent): string[] => {
         return [];
       }
       const es = Object.entries(
-        parsedContent as Record<string, { read?: boolean; write?: boolean }>
+        parsedContent as Record<string, { read?: boolean; write?: boolean }>,
       );
       return es.filter(([, usage]) => usage.write ?? false).map(([relay]) => relay);
     }

--- a/packages/nostr-fetch-kernel/src/adapterHelpers.ts
+++ b/packages/nostr-fetch-kernel/src/adapterHelpers.ts
@@ -1,0 +1,66 @@
+import { ChannelSender } from "./channel";
+import { FetchTillEoseAbortedSignal, FetchTillEoseOptions } from "./fetcherBackend";
+import { NostrEvent } from "./nostr";
+
+/**
+ * Helper that sets up two types of subscription abortions:
+ *
+ * - Auto-abortion when time (specified by `abortSubBeforeEoseTimeoutMs`) has passed without receiving any event since the last event was received
+ * - Abortion by an AbortController (if enabled by `abortSignal`)
+ *
+ * Returns a function to reset the timer for the auto-abortion. Implementers of the `NostrFetcherBackend` **MUST** make sure that the function is called each time received an event from a relay.
+ * Otherwise, the auto-abortion will not work collectly.
+ *
+ * @param closeSub A function that specify the logic of closing subscriptions.
+ * @param tx A sender endpoint of {@linkcode Channel}. It will be used to signal the abortion to the caller of this `NostrFetcherBackend`.
+ * @param options Pass `FetcherTillEoseOptions` down here.
+ * @returns A function which resets the timer for the auto-abortion.
+ *
+ * @example
+ * ```
+ * const [tx, chIter] = Channel.make<NostrEvent>();
+ * const sub = ...; // initializeing subscription
+ * const closeSub = () => {
+ *   sub.close();
+ *   // any cleanups for subscription go here
+ * }
+ * const resetAutoAbortTimer = setupSubscriptionAbortion(closeSub, tx, options);
+ *
+ * sub.on("event", (ev: NostrEvent) => {
+ *   tx.send(ev);
+ *   resetAutoAbortion(); // please call the function returned from `setupSubscriptionAbortion` each time you received an event!
+ * });
+ * ...
+ * ```
+ */
+export const setupSubscriptionAbortion = (
+  closeSub: () => void,
+  tx: ChannelSender<NostrEvent>,
+  options: FetchTillEoseOptions,
+): (() => void) => {
+  // auto abortion
+  let subAutoAbortTimer: NodeJS.Timer | undefined;
+  const resetAutoAbortTimer = () => {
+    if (subAutoAbortTimer !== undefined) {
+      clearTimeout(subAutoAbortTimer);
+      subAutoAbortTimer = undefined;
+    }
+    subAutoAbortTimer = setTimeout(() => {
+      closeSub();
+      tx.error(new FetchTillEoseAbortedSignal("subscription aborted before EOSE due to timeout"));
+    }, options.abortSubBeforeEoseTimeoutMs);
+  };
+  resetAutoAbortTimer(); // initiate subscription auto abortion timer
+
+  // handle abortion by AbortController
+  if (options.abortSignal?.aborted) {
+    closeSub();
+    tx.error(new FetchTillEoseAbortedSignal("subscription aborted by AbortController"));
+  }
+  options.abortSignal?.addEventListener("abort", () => {
+    closeSub();
+    tx.error(new FetchTillEoseAbortedSignal("subscription aborted by AbortController"));
+  });
+
+  return resetAutoAbortTimer;
+};

--- a/packages/nostr-fetch-kernel/src/channel.ts
+++ b/packages/nostr-fetch-kernel/src/channel.ts
@@ -17,7 +17,7 @@ export class Deferred<T> {
   }
 }
 
-interface ChannelSender<T> {
+export interface ChannelSender<T> {
   send(v: T): void;
   error(e: unknown): void;
   close(): void;

--- a/packages/nostr-fetch-kernel/src/fetcherBackend.ts
+++ b/packages/nostr-fetch-kernel/src/fetcherBackend.ts
@@ -27,7 +27,7 @@ export interface NostrFetcherBackend {
    * It should *normalize* the passed `relayUrls` before establishing connections to relays.
    *
    * Hint:
-   * You should make use of the function `normalizeRelayUrls` from `@nostr-fetch/kernel/utils` to normalize relay URLs.
+   * You should make use of the function `normalizeRelayUrlSet` from `@nostr-fetch/kernel/utils` to normalize a set of relay URLs.
    *
    */
   ensureRelays(relayUrls: string[], options: EnsureRelaysOptions): Promise<string[]>;

--- a/packages/nostr-fetch-kernel/src/nostr.ts
+++ b/packages/nostr-fetch-kernel/src/nostr.ts
@@ -1,5 +1,5 @@
 /**
- * Nostr event data structure
+ * The data structure of Nostr event.
  */
 export type NostrEvent = {
   id: string;
@@ -12,7 +12,7 @@ export type NostrEvent = {
 };
 
 /**
- * Known Nostr event kinds
+ * Known Nostr event kinds.
  */
 export const eventKind = {
   metadata: 0,
@@ -31,6 +31,7 @@ export const eventKind = {
   channelHideMessage: 43,
   channelMuteUser: 44,
   fileMetadata: 1063,
+  liveChatMessage: 1311,
   report: 1984,
   label: 1985,
   zapRequest: 9734,
@@ -52,6 +53,7 @@ export const eventKind = {
   marketplaceProduct: 30018,
   article: 30023,
   appSpecificData: 30078,
+  liveEvent: 30311,
   handlerRecommendation: 31989,
   handlerInformation: 31990,
 } as const;

--- a/packages/nostr-fetch-kernel/src/utils.spec.ts
+++ b/packages/nostr-fetch-kernel/src/utils.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { abbreviate, normalizeRelayUrl, normalizeRelayUrls, withTimeout } from "./utils";
+import { abbreviate, normalizeRelayUrl, normalizeRelayUrlSet, withTimeout } from "./utils";
 
 describe("normalizeRelayUrl", () => {
   test("normalizes a relay url", () => {
@@ -26,10 +26,10 @@ describe("normalizeRelayUrl", () => {
   });
 });
 
-describe("normalizeRelayUrls", () => {
+describe("normalizeRelayUrlSet", () => {
   test("normalizes relay urls and dedup", () => {
     expect(
-      normalizeRelayUrls([
+      normalizeRelayUrlSet([
         "wss://relay.example.com/",
         "wss://relay.example.com",
         "wss://relay.example.com:443",

--- a/packages/nostr-fetch-kernel/src/utils.ts
+++ b/packages/nostr-fetch-kernel/src/utils.ts
@@ -10,6 +10,11 @@ export const currUnixtimeSec = (now = new Date()): number =>
   Math.floor(currUnixtimeMilli(now) / 1000);
 
 // borrowed from nostr-tools (https://github.com/nbd-wtf/nostr-tools).
+/**
+ * Normalizes single URL of relay (WebSocket endpoint).
+ * @param urlStr
+ * @returns
+ */
 export const normalizeRelayUrl = (urlStr: string): string => {
   const url = new URL(urlStr);
 
@@ -35,11 +40,11 @@ const dedup = <T>(items: T[]): T[] => {
 };
 
 /**
- *  Normalizes each relay URL in `relayUrls`, then removes duplications.
+ * Normalizes all relay URLs, then removes duplications.
  *
- *  This function also filters out malformed URLs.
+ * It also filters out malformed URLs.
  */
-export const normalizeRelayUrls = (relayUrls: string[]): string[] => {
+export const normalizeRelayUrlSet = (relayUrls: string[]): string[] => {
   return dedup(
     relayUrls
       .filter((u) => {

--- a/packages/nostr-fetch/src/fetcher.ts
+++ b/packages/nostr-fetch/src/fetcher.ts
@@ -37,7 +37,14 @@ const MAX_LIMIT_PER_REQ_IN_BACKPRESSURE = 500;
 
 const MIN_HIGH_WATER_MARK = 5000;
 
+/**
+ * Structure of Nostr event filter except `limit`, `since` and `until`.
+ */
 export type FetchFilter = Omit<Filter, "limit" | "since" | "until">;
+
+/**
+ * Pair of timestamps which specifies time range of events to fetch.
+ */
 export type FetchTimeRangeFilter = Pick<Filter, "since" | "until">;
 
 /**

--- a/packages/nostr-fetch/src/index.ts
+++ b/packages/nostr-fetch/src/index.ts
@@ -2,4 +2,4 @@ export * from "./fetcher";
 export { FetchStats, FetchStatsListener, NostrFetchError } from "./types";
 
 export { NostrEvent, eventKind } from "@nostr-fetch/kernel/nostr";
-export { normalizeRelayUrl, normalizeRelayUrls } from "@nostr-fetch/kernel/utils";
+export { normalizeRelayUrl, normalizeRelayUrlSet } from "@nostr-fetch/kernel/utils";

--- a/packages/nostr-fetch/src/relayPool.ts
+++ b/packages/nostr-fetch/src/relayPool.ts
@@ -6,7 +6,7 @@ import { DebugLogger, LogLevel } from "@nostr-fetch/kernel/debugLogger";
 import {
   currUnixtimeMilli,
   normalizeRelayUrl,
-  normalizeRelayUrls,
+  normalizeRelayUrlSet,
 } from "@nostr-fetch/kernel/utils";
 
 // [NIP-01](https://github.com/nostr-protocol/nips/blob/master/01.md#other-notes) says:
@@ -143,7 +143,7 @@ class RelayPoolImpl implements RelayPool {
   }
 
   public async ensureRelays(relayUrls: string[], relayOpts: RelayOptions): Promise<string[]> {
-    const normalizedUrls = normalizeRelayUrls(relayUrls);
+    const normalizedUrls = normalizeRelayUrlSet(relayUrls);
     await this.addRelays(normalizedUrls, relayOpts);
 
     const connectedRelays: string[] = [];
@@ -158,7 +158,7 @@ class RelayPoolImpl implements RelayPool {
 
   public async ensureSingleRelay(
     relayUrl: string,
-    relayOpts: RelayOptions
+    relayOpts: RelayOptions,
   ): Promise<Relay | undefined> {
     const normalizedUrl = normalizeRelayUrl(relayUrl);
     await this.addRelays([normalizedUrl], relayOpts);

--- a/packages/nostr-fetch/src/testutil/fakedFetcher.ts
+++ b/packages/nostr-fetch/src/testutil/fakedFetcher.ts
@@ -10,7 +10,7 @@ import { Filter, NostrEvent, generateSubId } from "@nostr-fetch/kernel/nostr";
 import {
   emptyAsyncGen,
   normalizeRelayUrl,
-  normalizeRelayUrls,
+  normalizeRelayUrlSet,
   withTimeout,
 } from "@nostr-fetch/kernel/utils";
 import { FakeEventsSpec, generateFakeEvents } from "@nostr-fetch/testutil/fakeEvent";
@@ -156,7 +156,7 @@ class FakeFetcherBackend implements NostrFetcherBackend {
 
   async ensureRelays(relayUrls: string[], options: EnsureRelaysOptions): Promise<string[]> {
     const connected: string[] = [];
-    const normalizedUrls = normalizeRelayUrls(relayUrls);
+    const normalizedUrls = normalizeRelayUrlSet(relayUrls);
     await Promise.all(
       normalizedUrls.map(async (rurl) => {
         const relay = this.#mapFakeRelay.get(rurl);

--- a/packages/nostr-fetch/src/types.ts
+++ b/packages/nostr-fetch/src/types.ts
@@ -25,15 +25,15 @@ export type RelayStatus = "fetching" | "completed" | "aborted" | "failed";
  * Per-relay fetch statistics.
  */
 export type RelayFetchStats = {
-  /** Status of relays during a fetch */
+  /** Status of relays during a fetch. */
   status: RelayStatus;
 
-  /** Number of events fetched from the relay */
+  /** Number of events fetched from the relay. */
   numFetchedEvents: number;
 
   /**
    * "Frontier" of the event fetching.
-   * In other words, `created_at` of the oldest events fetched from the relay
+   * In other words, `created_at` of the oldest events fetched from the relay.
    */
   frontier: number;
 };
@@ -42,23 +42,23 @@ export type RelayFetchStats = {
  * Various statistics of the event fetching.
  */
 export type FetchStats = {
-  /** Overall progress of the event fetching */
+  /** Overall progress of the event fetching. */
   progress: {
     max: number;
     current: number;
   };
-  /** Events and subscriptions counts */
+  /** Events and subscriptions counts. */
   counts: {
-    /** Number of events fetched from relays so far */
+    /** Number of events fetched from relays so far. */
     fetchedEvents: number;
-    /** Number of events buffered in the internal buffer */
+    /** Number of events buffered in the internal buffer. */
     bufferedEvents: number;
-    /** Number of subscriptions opened so far */
+    /** Number of subscriptions opened so far. */
     openedSubs: number;
-    /** Number of subscriptions that is running */
+    /** Number of subscriptions that is running. */
     runningSubs: number;
   };
-  /** Per-relay fetch statistics */
+  /** Per-relay fetch statistics. */
   relays: {
     [relayUrl: string]: RelayFetchStats;
   };

--- a/packages/nostr-fetch/src/types.ts
+++ b/packages/nostr-fetch/src/types.ts
@@ -1,5 +1,5 @@
 /**
- * Type of errors that can be thrown from methods of `NostrFetcher`.
+ * Type of errors that can be thrown from `NostrFetcher` methods.
  */
 export class NostrFetchError extends Error {
   static {
@@ -9,28 +9,62 @@ export class NostrFetchError extends Error {
 
 /* stats */
 
+/**
+ * Status of relays during a fetch.
+ *
+ * Legend:
+ *
+ * - `fetching`: the fetcher is actively fetching events from the relay
+ * - `completed`: the fetcher have fetched enough events from the relay
+ * - `aborted`: Fetching from the relay is aborted
+ * - `failed`: An error occurred during fetching from the relay
+ */
 export type RelayStatus = "fetching" | "completed" | "aborted" | "failed";
 
+/**
+ * Per-relay fetch statistics.
+ */
 export type RelayFetchStats = {
+  /** Status of relays during a fetch */
   status: RelayStatus;
+
+  /** Number of events fetched from the relay */
   numFetchedEvents: number;
+
+  /**
+   * "Frontier" of the event fetching.
+   * In other words, `created_at` of the oldest events fetched from the relay
+   */
   frontier: number;
 };
 
+/**
+ * Various statistics of the event fetching.
+ */
 export type FetchStats = {
+  /** Overall progress of the event fetching */
   progress: {
     max: number;
     current: number;
   };
+  /** Events and subscriptions counts */
   counts: {
+    /** Number of events fetched from relays so far */
     fetchedEvents: number;
+    /** Number of events buffered in the internal buffer */
     bufferedEvents: number;
+    /** Number of subscriptions opened so far */
     openedSubs: number;
+    /** Number of subscriptions that is running */
     runningSubs: number;
   };
+  /** Per-relay fetch statistics */
   relays: {
     [relayUrl: string]: RelayFetchStats;
   };
 };
 
+/**
+ * Type of functions for listening fetch statistics.
+ */
 export type FetchStatsListener = (stats: FetchStats) => void;


### PR DESCRIPTION
- API change: renamed `normalizeRelayUrls` to `normalizeRelayUrlSet`
- Added helper to implement subscription abortion.
  - It is meant to be used by implementers of adapters (`NostrFetcherBackend`s)
- Added detailed doc comments for public APIs
