### PR TITLE
Fix rx-nostr adapter

### DIFF
--- a/packages/adapter-rx-nostr/src/adapter.ts
+++ b/packages/adapter-rx-nostr/src/adapter.ts
@@ -144,7 +144,10 @@ export class RxNostrAdapter implements NostrFetcherBackend {
         resetAutoAbortTimer();
         tx.send(event);
       },
-      complete: () => tx.close(),
+      complete: () => {
+        closeSub();
+        tx.close();
+      },
     });
 
     const noticeSub = this.#rxNostr

--- a/packages/examples/src/interop/relayPoolTs.ts
+++ b/packages/examples/src/interop/relayPoolTs.ts
@@ -5,7 +5,7 @@ import { RelayPool } from "nostr-relaypool";
 import { defaultRelays, nHoursAgo } from "../utils";
 
 const main = async () => {
-  // initialize fetcher based on nostr-relaypool's `RelayPool`
+  // initialize fetcher based on nostr-relaypool's RelayPool
   const pool = new RelayPool();
   const fetcher = NostrFetcher.withCustomPool(relayPoolAdapter(pool));
 

--- a/packages/examples/src/interop/rxNostr.ts
+++ b/packages/examples/src/interop/rxNostr.ts
@@ -6,7 +6,7 @@ import "websocket-polyfill";
 import { defaultRelays, nHoursAgo } from "../utils";
 
 const main = async () => {
-  // initialize fetcher based on nostr-relaypool's `RelayPool`
+  // initialize fetcher based on RxNostr
   const rxNostr = createRxNostr();
   const fetcher = NostrFetcher.withCustomPool(rxNostrAdapter(rxNostr));
 

--- a/packages/examples/src/interop/simplePool.ts
+++ b/packages/examples/src/interop/simplePool.ts
@@ -6,7 +6,7 @@ import "websocket-polyfill";
 import { defaultRelays, nHoursAgo } from "../utils";
 
 const main = async () => {
-  // initialize fetcher based on nostr-tools `SimplePool`
+  // initialize fetcher based on nostr-tools SimplePool
   const pool = new SimplePool();
   const fetcher = NostrFetcher.withCustomPool(simplePoolAdapter(pool));
 


### PR DESCRIPTION
Observers used in `fetchTillEose` is now unsubscribed correctly on EOSE.