### PR TITLE
Fix: matching an error with fetcher backend signal classes

### DIFF
--- a/packages/adapter-ndk/build.js
+++ b/packages/adapter-ndk/build.js
@@ -1,7 +1,9 @@
+import cp from "child_process";
 import { build } from "esbuild";
 import fs from "fs-extra";
 
 const DIST_DIR = "./dist";
+const BUILD_TS_CONFIG_PATH = "./tsconfig.build.json";
 
 /** @type import("esbuild").BuildOptions */
 const sharedBuildOptions = {
@@ -27,10 +29,22 @@ const buildESM = async () =>
     outExtension: { ".js": ".mjs" },
   });
 
+/** @type { () => Promise<void> } */
+const buildTypes = async () =>
+  new Promise((resolve, reject) => {
+    const proc = cp.spawn("yarn", ["tsc", "-p", BUILD_TS_CONFIG_PATH], { stdio: "inherit" });
+    proc.on("exit", (code) => {
+      if (code != null && code !== 0) {
+        reject(Error(`tsc exited with code ${code}`));
+      } else {
+        resolve();
+      }
+    });
+  });
 // remove outputs of the last build
 fs.rmSync(DIST_DIR, { force: true, recursive: true });
 
-Promise.all([buildCJS(), buildESM()]).catch((e) => {
+Promise.all([buildCJS(), buildESM(), buildTypes()]).catch((e) => {
   console.error(`failed to build: ${e}`);
   process.exit(1);
 });

--- a/packages/adapter-ndk/package.json
+++ b/packages/adapter-ndk/package.json
@@ -37,9 +37,8 @@
     "fix": "run-s fix:*",
     "fix:format": "prettier --write --log-level warn src/**/*.ts",
     "fix:js": "eslint --fix src/",
-    "build": "npm-run-all -p build:*",
-    "build:modules": "node build.js",
-    "build:types": "tsc -p tsconfig.build.json || exit 0"
+    "build": "run-s tsc build:*",
+    "build:modules": "node build.js"
   },
   "dependencies": {
     "@nostr-fetch/kernel": "^0.12.2"

--- a/packages/adapter-nostr-relaypool/build.js
+++ b/packages/adapter-nostr-relaypool/build.js
@@ -1,7 +1,9 @@
+import cp from "child_process";
 import { build } from "esbuild";
 import fs from "fs-extra";
 
 const DIST_DIR = "./dist";
+const BUILD_TS_CONFIG_PATH = "./tsconfig.build.json";
 
 /** @type import("esbuild").BuildOptions */
 const sharedBuildOptions = {
@@ -26,10 +28,24 @@ const buildESM = async () =>
     outExtension: { ".js": ".mjs" },
   });
 
+/** @type { () => Promise<void> } */
+const buildTypes = async () =>
+  new Promise((resolve) => {
+    const proc = cp.spawn("yarn", ["tsc", "-p", BUILD_TS_CONFIG_PATH], { stdio: "inherit" });
+    proc.on("exit", () => {
+      // if (code != null && code !== 0) {
+      //   reject(Error(`tsc exited with code ${code}`));
+      // } else {
+      //   resolve();
+      // }
+      resolve();
+    });
+  });
+
 // remove outputs of the last build
 fs.rmSync(DIST_DIR, { force: true, recursive: true });
 
-Promise.all([buildCJS(), buildESM()]).catch((e) => {
+Promise.all([buildCJS(), buildESM(), buildTypes()]).catch((e) => {
   console.error(`failed to build: ${e}`);
   process.exit(1);
 });

--- a/packages/adapter-nostr-relaypool/package.json
+++ b/packages/adapter-nostr-relaypool/package.json
@@ -37,9 +37,7 @@
     "fix": "run-s fix:*",
     "fix:format": "prettier --write --log-level warn src/**/*.ts",
     "fix:js": "eslint --fix src/",
-    "build": "npm-run-all -p build:*",
-    "build:modules": "node build.js",
-    "build:types": "tsc -p tsconfig.build.json || exit 0"
+    "build": "node build.js"
   },
   "dependencies": {
     "@nostr-fetch/kernel": "^0.12.2"

--- a/packages/adapter-nostr-tools/package.json
+++ b/packages/adapter-nostr-tools/package.json
@@ -37,9 +37,8 @@
     "fix": "run-s fix:*",
     "fix:format": "prettier --write --log-level warn src/**/*.ts",
     "fix:js": "eslint --fix src/",
-    "build": "npm-run-all tsc -p build:*",
-    "build:modules": "node build.js",
-    "build:types": "tsc -p tsconfig.build.json"
+    "build": "run-s tsc build:*",
+    "build:modules": "node build.js"
   },
   "dependencies": {
     "@nostr-fetch/kernel": "^0.12.2"

--- a/packages/adapter-rx-nostr/build.js
+++ b/packages/adapter-rx-nostr/build.js
@@ -1,7 +1,9 @@
+import cp from "child_process";
 import { build } from "esbuild";
 import fs from "fs-extra";
 
 const DIST_DIR = "./dist";
+const BUILD_TS_CONFIG_PATH = "./tsconfig.build.json";
 
 /** @type import("esbuild").BuildOptions */
 const sharedBuildOptions = {
@@ -27,10 +29,23 @@ const buildESM = async () =>
     outExtension: { ".js": ".mjs" },
   });
 
+/** @type { () => Promise<void> } */
+const buildTypes = async () =>
+  new Promise((resolve, reject) => {
+    const proc = cp.spawn("yarn", ["tsc", "-p", BUILD_TS_CONFIG_PATH], { stdio: "inherit" });
+    proc.on("exit", (code) => {
+      if (code != null && code !== 0) {
+        reject(Error(`tsc exited with code ${code}`));
+      } else {
+        resolve();
+      }
+    });
+  });
+
 // remove outputs of the last build
 fs.rmSync(DIST_DIR, { force: true, recursive: true });
 
-Promise.all([buildCJS(), buildESM()]).catch((e) => {
+Promise.all([buildCJS(), buildESM(), buildTypes()]).catch((e) => {
   console.error(`failed to build: ${e}`);
   process.exit(1);
 });

--- a/packages/adapter-rx-nostr/package.json
+++ b/packages/adapter-rx-nostr/package.json
@@ -37,9 +37,8 @@
     "fix": "run-s fix:*",
     "fix:format": "prettier --write --loglevel warn src/**/*.ts",
     "fix:js": "eslint --fix src/",
-    "build": "npm-run-all -p build:*",
-    "build:modules": "node build.js",
-    "build:types": "tsc -p tsconfig.build.json || exit 0"
+    "build": "run-s tsc build:*",
+    "build:modules": "node build.js"
   },
   "dependencies": {
     "@nostr-fetch/kernel": "^0.12.2"

--- a/packages/kernel/src/fetcherBackend.ts
+++ b/packages/kernel/src/fetcherBackend.ts
@@ -84,6 +84,22 @@ export class FetchTillEoseAbortedSignal extends Error {
 }
 
 /**
+ * Check if `err` is {@linkcode FetchTillEoseFailedSignal}.
+ *
+ * Note that you can't check that using `instanceof` operator.
+ */
+export const isFetchTillEoseFailedSignal = (err: unknown): err is FetchTillEoseFailedSignal =>
+  err instanceof Error && err.name === "FetchTillEoseFailedSignal";
+
+/**
+ * Check if `err` is {@linkcode FetchTillEoseAbortedSignal}.
+ *
+ * Note that you can't check that using `instanceof` operator.
+ */
+export const isFetchTillEoseAbortedSignal = (err: unknown): err is FetchTillEoseAbortedSignal =>
+  err instanceof Error && err.name === "FetchTillEoseAbortedSignal";
+
+/**
  * Common options for `NostrFetcher` and all `NostrFetcherBackend` implementations.
  */
 export type NostrFetcherCommonOptions = {

--- a/packages/nostr-fetch/package.json
+++ b/packages/nostr-fetch/package.json
@@ -37,9 +37,8 @@
     "fix": "run-s fix:*",
     "fix:format": "prettier --write --log-level warn src/**/*.ts",
     "fix:js": "eslint --fix src/",
-    "build": "npm-run-all tsc -p build:*",
+    "build": "run-s tsc build:*",
     "build:modules": "node build.js",
-    "build:types": "tsc -p tsconfig.build.json",
     "build:copy-doc": "copy-file ../../README.md ./README.md"
   },
   "dependencies": {

--- a/packages/nostr-fetch/src/fetcher.ts
+++ b/packages/nostr-fetch/src/fetcher.ts
@@ -3,13 +3,13 @@ import { verifyEventSig } from "@nostr-fetch/kernel/crypto";
 import { DebugLogger } from "@nostr-fetch/kernel/debugLogger";
 import {
   EnsureRelaysOptions,
-  FetchTillEoseAbortedSignal,
-  FetchTillEoseFailedSignal,
   FetchTillEoseOptions,
   NostrFetcherBackend,
   NostrFetcherBackendInitializer,
   NostrFetcherCommonOptions,
   defaultFetcherCommonOptions,
+  isFetchTillEoseAbortedSignal,
+  isFetchTillEoseFailedSignal,
 } from "@nostr-fetch/kernel/fetcherBackend";
 import { NostrEvent } from "@nostr-fetch/kernel/nostr";
 import { abbreviate, currUnixtimeSec, normalizeRelayUrlSet } from "@nostr-fetch/kernel/utils";
@@ -516,13 +516,13 @@ export class NostrFetcher {
               }
             }
           } catch (err) {
-            if (err instanceof FetchTillEoseFailedSignal) {
+            if (isFetchTillEoseFailedSignal(err)) {
               // an error occurred while fetching events
               logger?.log("error", err);
               statsMngr?.setRelayStatus(rurl, "failed");
               break;
             }
-            if (err instanceof FetchTillEoseAbortedSignal) {
+            if (isFetchTillEoseAbortedSignal(err)) {
               // fetch aborted
               logger?.log("info", err.message);
               isAboutToAbort = true;
@@ -740,13 +740,13 @@ export class NostrFetcher {
               }
             }
           } catch (err) {
-            if (err instanceof FetchTillEoseFailedSignal) {
+            if (isFetchTillEoseFailedSignal(err)) {
               // an error occurred while fetching events
               logger?.log("error", err);
               statsMngr?.setRelayStatus(rurl, "failed");
               break;
             }
-            if (err instanceof FetchTillEoseAbortedSignal) {
+            if (isFetchTillEoseAbortedSignal(err)) {
               // fetch aborted
               logger?.log("info", err.message);
               isAboutToAbort = true;
@@ -1063,14 +1063,14 @@ export class NostrFetcher {
               }
             }
           } catch (err) {
-            if (err instanceof FetchTillEoseFailedSignal) {
+            if (isFetchTillEoseFailedSignal(err)) {
               // an error occurred while fetching events
               logger?.log("error", err);
               statsMngr?.setRelayStatus(rurl, "failed");
               resolveAllOnEarlyBreak();
               break;
             }
-            if (err instanceof FetchTillEoseAbortedSignal) {
+            if (isFetchTillEoseAbortedSignal(err)) {
               // fetch aborted
               logger?.log("info", err.message);
               isAboutToAbort = true;


### PR DESCRIPTION
Until this fix, checking if an error is `FetchTillEoseAbortedSiglal`/`FetchTillEoseFailedSiglal` using `instanceof` always results in `false` due to bundling strategy.

Comparing the `name` property of an error solves the issue.

Aside, made `build` scripts build module bundles (via esbuild) and type definitions (via tsc) simultaneously. Until then, there was a little chance of building module bundles wipes out built type definitions.