### PR TITLE
Fix relay pool adapters

### DIFF
--- a/packages/adapter-ndk/README.md
+++ b/packages/adapter-ndk/README.md
@@ -25,3 +25,10 @@ const main = async () => {
     // ...
 }
 ```
+
+## Minimum Supported Version of NDK
+
+| adapter version | NDK version |
+|-----------------|-------------|
+| < 0.13.0        | 0.7.5       |
+| >= 0.13.0       | 0.8.4       |

--- a/packages/adapter-ndk/package.json
+++ b/packages/adapter-ndk/package.json
@@ -44,11 +44,11 @@
     "@nostr-fetch/kernel": "^0.12.2"
   },
   "devDependencies": {
-    "@nostr-dev-kit/ndk": "^0.8.0",
+    "@nostr-dev-kit/ndk": "^0.8.4",
     "nostr-fetch": "^0.12.2"
   },
   "peerDependencies": {
-    "@nostr-dev-kit/ndk": "^0.8.0",
+    "@nostr-dev-kit/ndk": "^0.8.4",
     "nostr-fetch": "^0.12.2"
   }
 }

--- a/packages/adapter-ndk/package.json
+++ b/packages/adapter-ndk/package.json
@@ -44,11 +44,11 @@
     "@nostr-fetch/kernel": "^0.12.2"
   },
   "devDependencies": {
-    "@nostr-dev-kit/ndk": "^0.7.5",
+    "@nostr-dev-kit/ndk": "^0.8.0",
     "nostr-fetch": "^0.12.2"
   },
   "peerDependencies": {
-    "@nostr-dev-kit/ndk": "^0.7.5",
+    "@nostr-dev-kit/ndk": "^0.8.0",
     "nostr-fetch": "^0.12.2"
   }
 }

--- a/packages/adapter-ndk/src/adapter.spec.ts
+++ b/packages/adapter-ndk/src/adapter.spec.ts
@@ -1,4 +1,4 @@
-import { FetchTillEoseOptions, NostrFetcherBackend } from "@nostr-fetch/kernel/fetcherBackend";
+import { FetchTillEoseOptions } from "@nostr-fetch/kernel/fetcherBackend";
 import { setupMockRelayServer } from "@nostr-fetch/testutil/mockRelayServer";
 import { NDKAdapter } from "./adapter";
 
@@ -36,7 +36,7 @@ describe("NDKAdapter", () => {
     };
 
     const url = "ws://localhost:8000/";
-    let backend: NostrFetcherBackend;
+    let backend: NDKAdapter;
     let wsServer: WS;
 
     beforeEach(async () => {
@@ -46,7 +46,7 @@ describe("NDKAdapter", () => {
       backend = new NDKAdapter(ndk, { minLogLevel: "none" });
     });
     afterEach(() => {
-      backend.shutdown(); // if we omit this line, a strange error occurs on the next line...
+      backend._hardShutdown(); // if we omit this line, a strange error occurs on the next line...
       WS.clean();
     });
 

--- a/packages/adapter-nostr-relaypool/README.md
+++ b/packages/adapter-nostr-relaypool/README.md
@@ -1,16 +1,27 @@
 # @nostr-fetch/adapter-nostr-relaypool
 
-This package includes the adapter for [nostr-relaypool's `RelayPool`](https://github.com/adamritter/nostr-relaypool-ts) which allows it to work with [**nostr-fetch**](https://github.com/jiftechnify/nostr-fetch), a utility library for fetching past events from Nostr relays.
+This package includes the adapter for
+[nostr-relaypool's `RelayPool`](https://github.com/adamritter/nostr-relaypool-ts)
+which allows it to work with
+[**nostr-fetch**](https://github.com/jiftechnify/nostr-fetch), a utility library
+for fetching past events from Nostr relays.
 
-If you want to use nostr-fetch, [here](https://github.com/jiftechnify/nostr-fetch#readme) is a good start point!
+If you want to use nostr-fetch,
+[here](https://github.com/jiftechnify/nostr-fetch#readme) is a good start point!
 
 ## Example
 
 ```ts
-import { RelayPool } from 'nostr-relaypool';
-import { NostrFetcher } from 'nostr-fetch';
-import { relayPoolAdapter } from '@nostr-fetch/adapter-nostr-relaypool'
+import { RelayPool } from "nostr-relaypool";
+import { NostrFetcher } from "nostr-fetch";
+import { relayPoolAdapter } from "@nostr-fetch/adapter-nostr-relaypool";
 
 const pool = new RelayPool();
 const fetcher = NostrFetcher.withCustomPool(relayPoolAdapter(pool));
 ```
+
+## Minimum Supported Version of nostr-relaypool
+
+| adapter version | nostr-relaypool version |
+| --------------- | ----------------------- |
+| *               | 0.6.28                  |

--- a/packages/adapter-nostr-tools/README.md
+++ b/packages/adapter-nostr-tools/README.md
@@ -14,3 +14,9 @@ import { simplePoolAdapter } from '@nostr-fetch/adapter-nostr-tools'
 const pool = new SimplePool();
 const fetcher = NostrFetcher.withCustomPool(simplePoolAdapter(pool));
 ```
+
+## Minimum Supported Version of nostr-tools
+
+| adapter version | nostr-tools version |
+|-----------------|---------------------|
+| *               | 1.3.0               |

--- a/packages/adapter-rx-nostr/README.md
+++ b/packages/adapter-rx-nostr/README.md
@@ -17,3 +17,10 @@ const main = async () => {
     // ...
 }
 ```
+
+## Minimum Supported Version of rx-nostr
+
+| adapter version | rx-nostr version |
+|-----------------|------------------|
+| < 0.13.0        | 1.1.0            |
+| >= 0.13.0       | 1.2.0            |

--- a/packages/adapter-rx-nostr/package.json
+++ b/packages/adapter-rx-nostr/package.json
@@ -45,12 +45,12 @@
   },
   "devDependencies": {
     "nostr-fetch": "^0.12.2",
-    "rx-nostr": "^1.1.0",
+    "rx-nostr": "^1.2.0",
     "rxjs": "^7.8.0"
   },
   "peerDependencies": {
     "nostr-fetch": "^0.12.2",
-    "rx-nostr": "^1.1.0",
+    "rx-nostr": "^1.2.0",
     "rxjs": "^7.8.0"
   }
 }

--- a/packages/adapter-rx-nostr/src/adapter.ts
+++ b/packages/adapter-rx-nostr/src/adapter.ts
@@ -49,9 +49,9 @@ export class RxNostrAdapter implements NostrFetcherBackend {
     for (const rurl of normalizedUrls) {
       const relayConf = relayConfs.get(rurl);
       if (relayConf === undefined) {
-        this.#rxNostr.addRelay({ url: rurl, read: true, write: false });
+        await this.#rxNostr.addRelay({ url: rurl, read: true, write: false });
       } else if (!relayConf.read) {
-        this.#rxNostr.addRelay({ url: rurl, read: true, write: relayConf.write });
+        await this.#rxNostr.addRelay({ url: rurl, read: true, write: relayConf.write });
       }
     }
 

--- a/packages/adapter-rx-nostr/src/adapter.ts
+++ b/packages/adapter-rx-nostr/src/adapter.ts
@@ -178,7 +178,7 @@ export class RxNostrAdapter implements NostrFetcherBackend {
   /**
    * Cleans up all the internal states of the fetcher.
    *
-   * Disconnects from relays managed by the adapter.
+   * Actually it does nothing.
    */
   public shutdown(): void {
     // do nothing

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -15,7 +15,7 @@
     "exec-ts": "node --loader esbuild-register/loader -r esbuild-register"
   },
   "dependencies": {
-    "@nostr-dev-kit/ndk": "^0.7.5",
+    "@nostr-dev-kit/ndk": "^0.8.0",
     "@nostr-fetch/adapter-ndk": "^0.12.2",
     "@nostr-fetch/adapter-nostr-relaypool": "^0.12.2",
     "@nostr-fetch/adapter-nostr-tools": "^0.12.2",

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -15,7 +15,7 @@
     "exec-ts": "node --loader esbuild-register/loader -r esbuild-register"
   },
   "dependencies": {
-    "@nostr-dev-kit/ndk": "^0.8.0",
+    "@nostr-dev-kit/ndk": "^0.8.4",
     "@nostr-fetch/adapter-ndk": "^0.12.2",
     "@nostr-fetch/adapter-nostr-relaypool": "^0.12.2",
     "@nostr-fetch/adapter-nostr-tools": "^0.12.2",

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -23,7 +23,7 @@
     "nostr-fetch": "^0.12.2",
     "nostr-relaypool": "^0.6.28",
     "nostr-tools": "^1.13.1",
-    "rx-nostr": "^1.1.0",
+    "rx-nostr": "^1.2.0",
     "rxjs": "^7.8.0",
     "websocket-polyfill": "^0.0.3",
     "ws": "^8.13.0"

--- a/packages/examples/src/utils.ts
+++ b/packages/examples/src/utils.ts
@@ -5,7 +5,7 @@ export const nHoursAgo = (hrs: number): number =>
 
 export const defaultRelays = [
   "wss://relay-jp.nostr.wirednet.jp",
-  "wss://nostr.h3z.jp",
+  "wss://nrelay.c-stellar.net",
   "wss://nostr.holybea.com",
   "wss://nostr-relay.nokotaro.com",
   "wss://relay.damus.io",

--- a/packages/nostr-fetch/src/index.ts
+++ b/packages/nostr-fetch/src/index.ts
@@ -1,11 +1,11 @@
 export * from "./fetcher";
 export {
-  FetchFilter,
-  FetchStats,
-  FetchStatsListener,
-  FetchTimeRangeFilter,
   NostrFetchError,
+  type FetchFilter,
+  type FetchStats,
+  type FetchStatsListener,
+  type FetchTimeRangeFilter,
 } from "./types";
 
-export { NostrEvent, eventKind } from "@nostr-fetch/kernel/nostr";
+export { eventKind, type NostrEvent } from "@nostr-fetch/kernel/nostr";
 export { normalizeRelayUrl, normalizeRelayUrlSet } from "@nostr-fetch/kernel/utils";


### PR DESCRIPTION
- Dealt with breaking changes of NDK and rx-nostr
- Bumped minimum supported version of the adaptee for each adapter
  - adapter-ndk: 0.7.5 -> 0.8.4
  - rx-nostr: 1.1.0 -> 1.2.0