### PR TITLE
Improve fetch stats

### DIFF
--- a/packages/examples/src/statsListener.ts
+++ b/packages/examples/src/statsListener.ts
@@ -5,7 +5,7 @@ import { defaultRelays, nHoursAgo } from "./utils";
 
 const main = async () => {
   // initialize fetcher based on nostr-relaypool's `RelayPool`
-  const fetcher = NostrFetcher.init({ minLogLevel: "info" });
+  const fetcher = NostrFetcher.init();
 
   // fetch all text events (kind: 1) posted in the last hour from the relays
   const eventsIter = fetcher.allEventsIterator(

--- a/packages/nostr-fetch/src/fetcherHelper.ts
+++ b/packages/nostr-fetch/src/fetcherHelper.ts
@@ -1,6 +1,7 @@
 import { DebugLogger } from "@nostr-fetch/kernel/debugLogger";
 import { NostrFetcherCommonOptions } from "@nostr-fetch/kernel/fetcherBackend";
 import { NostrEvent, querySupportedNips } from "@nostr-fetch/kernel/nostr";
+import { normalizeRelayUrlSet } from ".";
 import {
   FetchFilterKeyElem,
   FetchFilterKeyName,
@@ -385,17 +386,30 @@ export class FetchStatsManager {
   }
 
   /* relay stats */
-  initRelayStats(rurls: string[], initUntil: number): void {
-    this.#relayStatsMap = new Map(
-      rurls.map((rurl) => [
-        rurl,
-        {
-          status: "fetching",
-          numFetchedEvents: 0,
-          frontier: initUntil,
-        },
-      ]),
-    );
+  initRelayStats(allReleys: string[], connectedRelays: string[], initUntil: number): void {
+    const connectedSet = new Set(connectedRelays);
+    const failedRelays = normalizeRelayUrlSet(allReleys).filter((r) => !connectedSet.has(r));
+
+    console.log(allReleys, connectedRelays, failedRelays);
+
+    const connectedEntries: [string, RelayFetchStats][] = connectedRelays.map((rurl) => [
+      rurl,
+      {
+        status: "fetching",
+        numFetchedEvents: 0,
+        frontier: initUntil,
+      },
+    ]);
+    const failedEntries: [string, RelayFetchStats][] = failedRelays.map((rurl) => [
+      rurl,
+      {
+        status: "connection-failed",
+        numFetchedEvents: 0,
+        frontier: 0,
+      },
+    ]);
+
+    this.#relayStatsMap = new Map([...connectedEntries, ...failedEntries]);
   }
 
   setRelayStatus(rurl: string, status: RelayStatus): void {

--- a/packages/nostr-fetch/src/fetcherHelper.ts
+++ b/packages/nostr-fetch/src/fetcherHelper.ts
@@ -308,7 +308,7 @@ class SeenEventsSet implements SeenEvents<false> {
 }
 
 export class FetchStatsManager {
-  #stats: Omit<FetchStats, "relays"> = {
+  #stats: Omit<FetchStats, "relays" | "elapsedTimeMs"> = {
     progress: {
       max: 1, // prevent division by 0
       current: 0,
@@ -320,6 +320,7 @@ export class FetchStatsManager {
       runningSubs: 0,
     },
   };
+  #startedAt: number = performance.now();
   #relayStatsMap: Map<string, RelayFetchStats> = new Map();
   #cb: FetchStatsListener;
   #timer: NodeJS.Timeout | undefined;
@@ -332,7 +333,11 @@ export class FetchStatsManager {
   }
 
   #renderStats(): FetchStats {
-    return { ...this.#stats, relays: Object.fromEntries(this.#relayStatsMap) };
+    return {
+      ...this.#stats,
+      elapsedTimeMs: performance.now() - this.#startedAt,
+      relays: Object.fromEntries(this.#relayStatsMap),
+    };
   }
 
   static init(

--- a/packages/nostr-fetch/src/types.ts
+++ b/packages/nostr-fetch/src/types.ts
@@ -37,8 +37,9 @@ export class NostrFetchError extends Error {
  * - `completed`: the fetcher have fetched enough events from the relay
  * - `aborted`: Fetching from the relay is aborted
  * - `failed`: An error occurred during fetching from the relay
+ * - `connection-failed`: An error occured during connecting to the relay
  */
-export type RelayStatus = "fetching" | "completed" | "aborted" | "failed";
+export type RelayStatus = "fetching" | "completed" | "aborted" | "failed" | "connection-failed";
 
 /**
  * Per-relay fetch statistics.

--- a/packages/nostr-fetch/src/types.ts
+++ b/packages/nostr-fetch/src/types.ts
@@ -61,6 +61,8 @@ export type RelayFetchStats = {
  * Various statistics of the event fetching.
  */
 export type FetchStats = {
+  /** Elapsed time in millisecond */
+  elapsedTimeMs: number;
   /** Overall progress of the event fetching. */
   progress: {
     max: number;


### PR DESCRIPTION
- Added elapsed time (in millisecond)
- Added relay status: `connection-failed`. It indicates that an attempt to connect to the relay failed