### PR TITLE
Add ability to fetch latest events as of specified time

### DIFF
--- a/packages/examples/src/fetchLatestAsOf.ts
+++ b/packages/examples/src/fetchLatestAsOf.ts
@@ -1,0 +1,32 @@
+import { eventKind, NostrFetcher } from "nostr-fetch";
+import "websocket-polyfill";
+
+import { defaultRelays } from "./utils";
+
+const main = async () => {
+  const fetcher = NostrFetcher.init();
+
+  // fetch the latest 100 text events (kind: 1) from the relays **as of** 2023-08-31 12:00:00 (UTC)
+  const latestPosts = await fetcher.fetchLatestEvents(
+    defaultRelays,
+    {
+      kinds: [eventKind.text],
+    },
+    100,
+    { asOf: Math.floor(new Date("2023-08-31T12:00:00Z").getTime() / 1000) },
+  );
+
+  console.log(`got ${latestPosts.length} events`);
+  for (const e of latestPosts) {
+    console.log(`${e.content} (${new Date(e.created_at * 1000).toISOString()})`);
+  }
+
+  fetcher.shutdown();
+};
+
+main()
+  .then(() => console.log("fin"))
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });

--- a/packages/nostr-fetch/src/fetcher.ts
+++ b/packages/nostr-fetch/src/fetcher.ts
@@ -212,6 +212,11 @@ const defaultFetchAllOptions: Required<FetchAllOptions> = {
  */
 export type FetchLatestOptions<SeenOn extends boolean = false> = FetchOptions<SeenOn> & {
   /**
+   * Takes unixtime in second.  If specified, fetch latest events **as of the time**.
+   */
+  asOf?: number | undefined;
+
+  /**
    * If true, the "reduced verification" mode is enabled.
    *
    * In the reduced verification mode, event signature verification is performed only to minimum amount of events enough to ensure validity.
@@ -223,6 +228,7 @@ export type FetchLatestOptions<SeenOn extends boolean = false> = FetchOptions<Se
 
 const defaultFetchLatestOptions: Required<FetchLatestOptions> = {
   ...defaultFetchOptions,
+  asOf: undefined,
   reduceVerification: true,
 };
 
@@ -682,7 +688,7 @@ export class NostrFetcher {
 
     const [tx, chIter] = Channel.make<NostrEvent>();
     const globalSeenEvents = initSeenEvents(finalOpts.withSeenOn);
-    const initialUntil = currUnixtimeSec();
+    const initialUntil = finalOpts.asOf ?? currUnixtimeSec();
 
     const progTracker = new ProgressTracker(eligibleRelayUrls);
     statsMngr?.setProgressMax(eligibleRelayUrls.length * limit);
@@ -979,7 +985,7 @@ export class NostrFetcher {
 
     const [tx, chIter] = Channel.make<NostrEventListWithKey<K, SeenOn>>();
     const globalSeenEvents = initSeenEvents(options.withSeenOn);
-    const initialUntil = currUnixtimeSec();
+    const initialUntil = options.asOf ?? currUnixtimeSec();
 
     statsMngr?.setProgressMax(allKeys.length);
     statsMngr?.initRelayStats([...relayToKeys.keys()], initialUntil);


### PR DESCRIPTION
Added **`asOf`** property to options for `fetchLatestEvents`/`fetchLastEvent` series of fetcher methods.

`asOf` must be set to unixtime (in seconds) of a some point in the past. If you specify it, the fetcher fetches latest N events **as of** that time.

You can find an example at: `packages/examples/src/fetchLatestAsOf.ts`

resolves #89.