### PR TITLE
Workaround a problem with workerd

### DIFF
--- a/packages/kernel/src/webSocket.ts
+++ b/packages/kernel/src/webSocket.ts
@@ -1,0 +1,14 @@
+/**
+ * Constants for WebSocket ready states.
+ *
+ * When you check the ready state of a WebSocket, you should use them
+ * instead of constants defined in the `WebSocket` class to workaround
+ * problems that are caused by the fact that constants for ready states
+ * have different name in workerd (runtime of Cloudflare Workers).
+ */
+export enum WebSocketReadyState {
+  CONNECTING = 0,
+  OPEN = 1,
+  CLOSING = 2,
+  CLOSED = 3,
+}

--- a/packages/nostr-fetch/src/relay.spec.ts
+++ b/packages/nostr-fetch/src/relay.spec.ts
@@ -12,6 +12,7 @@ import type {
 } from "./relay";
 import { initRelay } from "./relay";
 
+import { WebSocketReadyState } from "@nostr-fetch/kernel/webSocket";
 import { setTimeout as delay } from "node:timers/promises";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import WS from "vitest-websocket-mock";
@@ -37,10 +38,10 @@ describe("Relay", () => {
       await expect(
         r.connect().then((r) => {
           return { url: r.url, readyState: r.wsReadyState };
-        })
+        }),
       ).resolves.toStrictEqual({
         url: rurl,
-        readyState: WebSocket.OPEN,
+        readyState: WebSocketReadyState.OPEN,
       });
 
       r.close();

--- a/packages/nostr-fetch/src/relay.ts
+++ b/packages/nostr-fetch/src/relay.ts
@@ -1,6 +1,7 @@
 import { verifyEventSig } from "@nostr-fetch/kernel/crypto";
 import type { C2RMessage, Filter, NostrEvent } from "@nostr-fetch/kernel/nostr";
 import { generateSubId, parseR2CMessage } from "@nostr-fetch/kernel/nostr";
+import { WebSocketReadyState } from "@nostr-fetch/kernel/webSocket";
 
 type Callback<E> = E extends void ? () => void : (ev: E) => void;
 
@@ -75,7 +76,7 @@ class RelayImpl implements Relay {
   }
 
   public get wsReadyState(): number {
-    return this.#ws?.readyState ?? WebSocket.CONNECTING;
+    return this.#ws?.readyState ?? WebSocketReadyState.CONNECTING;
   }
 
   private forwardToSub(subId: string, forwardFn: (sub: RelaySubscription) => void) {
@@ -199,7 +200,7 @@ class RelayImpl implements Relay {
   }
 
   _sendC2RMessage(msg: C2RMessage) {
-    if (this.#ws === undefined || this.#ws.readyState !== WebSocket.OPEN) {
+    if (this.#ws === undefined || this.#ws.readyState !== WebSocketReadyState.OPEN) {
       throw Error("not connected to the relay");
     }
     this.#ws.send(JSON.stringify(msg));

--- a/packages/nostr-fetch/src/relayPool.ts
+++ b/packages/nostr-fetch/src/relayPool.ts
@@ -8,6 +8,7 @@ import {
   normalizeRelayUrl,
   normalizeRelayUrlSet,
 } from "@nostr-fetch/kernel/utils";
+import { WebSocketReadyState } from "@nostr-fetch/kernel/webSocket";
 
 // [NIP-01](https://github.com/nostr-protocol/nips/blob/master/01.md#other-notes) says:
 // > When a websocket is closed by the relay with a status code 4000 that means the client shouldn't try to connect again.
@@ -79,7 +80,7 @@ class RelayPoolImpl implements RelayPool {
     return (
       (relay.state === "connectFailed" && currUnixtimeMilli() - relay.failedAt > 30 * 1000) ||
       (relay.state === "disconnected" && relay.reconnectable) ||
-      (relay.state === "alive" && relay.relay.wsReadyState === WebSocket.CLOSED) // is it possible?
+      (relay.state === "alive" && relay.relay.wsReadyState === WebSocketReadyState.CLOSED) // is it possible?
     );
   }
 


### PR DESCRIPTION
In workerd (runtime of Cloudflare Workers), constants of WebSocket ready states have different name than names defined in the Living Standard (e.g. `WebSocket.OPEN` (standard) vs `WebSocket.READY_STATE_OPEN` (workerd)).

So when we check the state of WebSocket via "standard" ready state constants on Cloudflare Workers, the value of that becomes `undefined` and cause problems.

To workaround this issue, I defined custom ready state constants in the kernel and use them for checking socket state, instead of "standard" ready state constants.