### PR TITLE
Simplify event go-backing algorithm

### DIFF
--- a/packages/nostr-fetch/src/fetcher.spec.ts
+++ b/packages/nostr-fetch/src/fetcher.spec.ts
@@ -58,21 +58,20 @@ describe.concurrent("NostrFetcher", () => {
       eventsSpec: [
         {
           content: "test3 early",
-          createdAt: { since: 0, until: 1000 },
+          createdAt: { since: 0, until: 999 },
           n: 10,
         },
         {
           content: "test3 within range",
-          createdAt: { since: 1001, until: 1999 }, // it's correct because this relay is "exclusive" wrt since/until
+          createdAt: { since: 1000, until: 2000 },
           n: 10,
         },
         {
           content: "test3 late",
-          createdAt: { since: 2000, until: 3000 },
+          createdAt: { since: 2001, until: 3000 },
           n: 10,
         },
       ],
-      exclusiveInterval: true,
     })
     .addRelay("wss://dup1/", {
       eventsSpec: [{ content: "dup" }],

--- a/packages/nostr-fetch/src/fetcher.ts
+++ b/packages/nostr-fetch/src/fetcher.ts
@@ -551,8 +551,7 @@ export class NostrFetcher {
           }
 
           // set next `until` to `created_at` of the oldest event returned in this time.
-          // `+ 1` is needed to make it work collectly even if we used relays which has "exclusive" behaviour with respect to `until`.
-          nextUntil = oldestCreatedAt + 1;
+          nextUntil = oldestCreatedAt;
           statsMngr?.setRelayFrontier(rurl, oldestCreatedAt);
 
           // update progress
@@ -785,8 +784,7 @@ export class NostrFetcher {
           }
 
           // set next `until` to `created_at` of the oldest event returned in this time.
-          // `+ 1` is needed to make it work collectly even if we used relays which has "exclusive" behaviour with respect to `until`.
-          nextUntil = oldestCreatedAt + 1;
+          nextUntil = oldestCreatedAt;
           statsMngr?.setRelayFrontier(rurl, oldestCreatedAt);
         }
         // subscripton loop for the relay terminated
@@ -1111,7 +1109,8 @@ export class NostrFetcher {
             break;
           }
 
-          nextUntil = oldestCreatedAt + 1;
+          // set next `until` to `created_at` of the oldest event returned in this time.
+          nextUntil = oldestCreatedAt;
           statsMngr?.setRelayFrontier(rurl, oldestCreatedAt);
         }
       }),


### PR DESCRIPTION
Assuming all relays treat time-range filters as inclusive.

resolves #156.